### PR TITLE
[engine] add remote call optimization

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -426,6 +426,7 @@ func buildExpr(cc *CompileConfig, ast *astNode, size int) *Expr {
 	calAndSetParentIndex(e, ast)
 	calAndSetStackSize(e)
 	calAndSetShortCircuit(e)
+	calAndSetShortCircuitForRCO(e)
 	if cc.CompileOptions[Debug] {
 		calAndSetDebugInfo(e)
 	}
@@ -628,6 +629,20 @@ func calAndSetShortCircuit(e *Expr) {
 			n.scIdx = -1
 		} else {
 			n.scIdx = f[i]
+		}
+	}
+}
+
+func calAndSetShortCircuitForRCO(e *Expr) {
+	for i, n := range e.nodes {
+		p, _ := parentNode(e, int16(i))
+		switch {
+		case p == nil:
+			continue
+		case isAndOpNode(p):
+			n.flag |= andOp
+		case isOrOpNode(p):
+			n.flag |= orOp
 		}
 	}
 }

--- a/engine.go
+++ b/engine.go
@@ -272,16 +272,16 @@ func (e *Expr) EvalRCO(ctx *Ctx) (res Value, err error) {
 		}
 
 		for matchesShortCircuit(res, curt) {
+			// jump to parent node
 			curt, i = parentNode(e, i)
 			if i == -1 {
 				return
 			}
-			if curt.flag&nodeTypeMask == cond {
-				if !matchesShortCircuit(res, curt) {
-					i = nodes[curt.scIdx].scIdx
-					osTop = nodes[i].osTop - 1
-					break
-				}
+			if curt.flag&nodeTypeMask == cond &&
+				!matchesShortCircuit(res, curt) {
+				i = nodes[curt.scIdx].scIdx
+				osTop = nodes[i].osTop - 1
+				break
 			} else {
 				osTop = curt.osTop - 1
 			}

--- a/engine_test.go
+++ b/engine_test.go
@@ -536,7 +536,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 }
 
 func TestExpr_EvalRCO(t *testing.T) {
-	const debugMode = true
+	const debugMode = false
 
 	type optimizeLevel int
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func TestDebugCases(t *testing.T) {
+func TestExpr_Eval(t *testing.T) {
 	const debugMode = false
 
 	type optimizeLevel int
@@ -975,11 +975,11 @@ func TestExpr_EvalRCO(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 10000
+		size          = 3000000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = false
+		printProgress = true
 	)
 
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -975,11 +975,11 @@ func TestExpr_EvalRCO(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = true
+		printProgress = false
 	)
 
 	const (

--- a/selector.go
+++ b/selector.go
@@ -13,7 +13,14 @@ var (
 	}
 )
 
+// UndefinedSelKey means that the current key is defined in the SelectorKey type
+// In this case you should use the string type key
 const UndefinedSelKey SelectorKey = math.MinInt16
+
+// DNE means Does Not Exist, it used in RCO (remote call optimization).
+// When executing an expression with RCO, if the value of a SelectorKey is not cached,
+// the selector proxy will return DNE as its value
+var DNE = struct{ DoesNotExist string }{DoesNotExist: "DNE"}
 
 // Selector is used to get values of the expression variables.
 // Note that there are two types of keys in each method parameters,


### PR DESCRIPTION
## Summary
This PR adds a new feature of **RCO** (_Remote Call Optimization_), It avoids remote calls and tries to execute the final result with cached selectors only.

Quota from the article [Making the LinkedIn experimentation engine 20x faster](https://engineering.linkedin.com/blog/2020/making-the-linkedin-experimentation-engine-20x-faster)  of the LinkedIn Eng Blog.
> To perform segmentation, operations usually require member attribute data, which results in a network call and increased latency of evaluation. While full local evaluation can be executed as fast as 50ns, the remote call has a p99 latency of 4ms. For example, the is-student operation we talked about in Figure 1 needs to fetch members’ education data to process, but some operations don’t require remote call, so we can use that to our advantage and avoid doing the expensive query. In the example below, we will not be performing the remote call if string-property “osVersion” does not return “7.1.1”:
```
(ab (and (ge (connection-count) 30) (= (string-property “osVersion”) “7.1.1”)) [treatment 50]) 
```

> Technically, the optimization is to disable short-circuiting of “and” and “or” operations during local execution and to try to find at least one child branch of them that can be fully executed locally and returns “false.” 

Please refer the origin article (https://engineering.linkedin.com/blog/2020/making-the-linkedin-experimentation-engine-20x-faster) for more details.


## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/onheap/eval	1.843s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	56741073	        63.36 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	55322466	        63.75 ns/op	      32 B/op	       1 allocs/op
BenchmarkReference-16     	78091005	        45.83 ns/op	      23 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	54617013	        63.57 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	54846603	        64.24 ns/op	      32 B/op	       1 allocs/op
BenchmarkReference1-16    	68381778	        48.53 ns/op	      23 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/local	24.749s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     36242|     30000|      3789|        53|    2.172s|
|       2 %|       2 %|     69726|     60000|      7313|        13|    3.946s|
|       3 %|       3 %|     92730|     90000|        56|       274|    4.373s|
|       4 %|       4 %|    123540|    120000|      1072|        68|    4.255s|
|       5 %|       5 %|    153679|    150000|      1105|       174|    4.428s|
|       6 %|       6 %|    182490|    180000|        48|        42|    4.744s|
|       7 %|       7 %|    212471|    210000|        58|        13|    4.314s|
|       8 %|       8 %|    246386|    240000|      3976|        10|    4.898s|
|       9 %|       9 %|    272824|    270000|       193|       231|    4.459s|
|      10 %|      10 %|    302621|    300000|        56|       165|    4.283s|
|      11 %|      11 %|    332996|    330000|       529|        67|    4.236s|
|      12 %|      12 %|    362661|    360000|       210|        51|    4.305s|
|      13 %|      13 %|    392785|    390000|       334|        51|    4.998s|
|      14 %|      14 %|    422555|    420000|        24|       131|    4.679s|
|      15 %|      15 %|    453032|    450000|       424|       208|    5.173s|
|      16 %|      16 %|    482557|    480000|        99|        58|    5.362s|
|      17 %|      17 %|    512812|    510000|       412|         0|    5.259s|
|      18 %|      18 %|    542397|    540000|         0|         0|    5.133s|
|      19 %|      19 %|    572844|    570000|       366|        78|    4.886s|
|      20 %|      20 %|    602444|    600000|        44|         0|    4.947s|
|      21 %|      21 %|    632490|    630000|        87|         3|      4.9s|
|      22 %|      22 %|    662392|    660000|         0|         0|    4.801s|
|      23 %|      23 %|    692814|    690000|       289|       125|     4.76s|
|      24 %|      24 %|    722863|    720000|       428|        35|    4.706s|
|      25 %|      25 %|    752704|    750000|       104|       200|    4.739s|
|      26 %|      26 %|    782424|    780000|        21|         3|     4.86s|
|      27 %|      27 %|    812968|    810000|       389|       180|    4.924s|
|      28 %|      28 %|    842638|    840000|       233|         5|    5.231s|
|      29 %|      29 %|    872519|    870000|       112|         8|    5.258s|
|      30 %|      30 %|    902398|    900000|         0|         0|    4.932s|
|      31 %|      31 %|    932456|    930000|        42|        14|    4.961s|
|      32 %|      32 %|    962585|    960000|       141|        44|    4.994s|
|      33 %|      33 %|    992617|    990000|       114|       103|    5.012s|
|      34 %|      34 %|   1022449|   1020000|         0|        55|    4.999s|
|      35 %|      35 %|   1052603|   1050000|       196|         7|    5.274s|
|      36 %|      36 %|   1082830|   1080000|       398|        32|    4.928s|
|      37 %|      37 %|   1112465|   1110000|        63|         2|    4.896s|
|      38 %|      38 %|   1142464|   1140000|         2|        62|     4.76s|
|      39 %|      39 %|   1172535|   1170000|       123|        12|    4.793s|
|      40 %|      40 %|   1202525|   1200000|       124|         1|    4.961s|
|      41 %|      41 %|   1232578|   1230000|        97|        81|    4.827s|
|      42 %|      42 %|   1263185|   1260000|       106|       679|    5.193s|
|      43 %|      43 %|   1292391|   1290000|         0|         0|    4.917s|
|      44 %|      44 %|   1323548|   1320000|       997|       151|    5.315s|
|      45 %|      45 %|   1353072|   1350000|       673|         0|    5.327s|
|      46 %|      46 %|   1382543|   1380000|        73|        70|    4.933s|
|      47 %|      47 %|   1412541|   1410000|       141|         0|    5.173s|
|      48 %|      48 %|   1442442|   1440000|        23|        19|    5.034s|
|      49 %|      49 %|   1472535|   1470000|       127|         8|    5.596s|
|      50 %|      50 %|   1503007|   1500000|       436|       171|    4.917s|
|      51 %|      51 %|   1532533|   1530000|        43|        90|    4.617s|
|      52 %|      52 %|   1562860|   1560000|       316|       144|    4.604s|
|      53 %|      53 %|   1592595|   1590000|       125|        70|    4.862s|
|      54 %|      54 %|   1622586|   1620000|       140|        46|    4.867s|
|      55 %|      55 %|   1652758|   1650000|       331|        27|    5.028s|
|      56 %|      56 %|   1682781|   1680000|       313|        68|    4.996s|
|      57 %|      57 %|   1712655|   1710000|       202|        53|    5.697s|
|      58 %|      58 %|   1742996|   1740000|       516|        80|    4.883s|
|      59 %|      59 %|   1772467|   1770000|        64|         3|    4.834s|
|      60 %|      60 %|   1803300|   1800000|       687|       213|     5.04s|
|      61 %|      61 %|   1832491|   1830000|        68|        23|    5.026s|
|      62 %|      62 %|   1862493|   1860000|        84|         9|     4.82s|
|      63 %|      63 %|   1892506|   1890000|        32|        74|    5.039s|
|      64 %|      64 %|   1922463|   1920000|         0|        75|    4.941s|
|      65 %|      65 %|   1958697|   1950000|      6224|        73|    3.045s|
|      66 %|      66 %|   1986510|   1980000|      4005|       105|    4.893s|
|      67 %|      67 %|   2012614|   2010000|       159|        55|    4.816s|
|      68 %|      68 %|   2042449|   2040000|         2|        47|    4.881s|
|      69 %|      69 %|   2072869|   2070000|       272|       197|    4.974s|
|      70 %|      70 %|   2102441|   2100000|         0|        47|    4.968s|
|      71 %|      71 %|   2133854|   2130000|      1454|         0|    5.051s|
|      72 %|      72 %|   2163273|   2160000|       709|       164|    5.126s|
|      73 %|      73 %|   2192338|   2190000|         0|         0|     5.11s|
|      74 %|      74 %|   2222523|   2220000|        86|        37|    4.984s|
|      75 %|      75 %|   2254679|   2250000|      1919|       360|    5.009s|
|      76 %|      76 %|   2282457|   2280000|        45|        12|     4.85s|
|      77 %|      77 %|   2312438|   2310000|         0|        41|    4.993s|
|      78 %|      78 %|   2343973|   2340000|      1533|        40|    4.969s|
|      79 %|      79 %|   2372479|   2370000|        58|        21|    4.983s|
|      80 %|      80 %|   2402662|   2400000|        90|       172|    5.012s|
|      81 %|      81 %|   2432854|   2430000|        12|       442|    5.078s|
|      82 %|      82 %|   2468421|   2460000|      5806|       215|    4.933s|
|      83 %|      83 %|   2496404|   2490000|      3980|        24|    4.981s|
|      84 %|      84 %|   2522458|   2520000|         0|        63|    4.658s|
|      85 %|      85 %|   2552678|   2550000|       147|       131|    5.097s|
|      86 %|      86 %|   2582578|   2580000|        60|       118|    5.064s|
|      87 %|      87 %|   2612614|   2610000|       104|       110|    5.091s|
|      88 %|      88 %|   2642567|   2640000|        69|        98|    4.798s|
|      89 %|      89 %|   2673125|   2670000|       126|       599|    5.322s|
|      90 %|      90 %|   2702991|   2700000|       446|       145|    5.717s|
|      91 %|      91 %|   2732520|   2730000|         0|       133|    5.566s|
|      92 %|      92 %|   2762833|   2760000|       433|         0|    5.313s|
|      93 %|      93 %|   2792498|   2790000|        49|        49|    5.783s|
|      94 %|      94 %|   2822497|   2820000|        96|         1|    5.205s|
|      95 %|      95 %|   2852815|   2850000|        63|       352|    5.747s|
|      96 %|      96 %|   2882561|   2880000|       113|        48|    5.369s|
|      97 %|      97 %|   2912413|   2910000|        12|         1|    5.257s|
|      98 %|      98 %|   2942469|   2940000|        54|        15|    5.106s|
|      99 %|      99 %|   2972445|   2970000|        34|        11|    5.381s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.266s|
PASS
ok  	github.com/onheap/eval	497.199s
```

## Reviewers
@larry618