### PR TITLE
[parse] support infix expression

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -71,6 +71,9 @@ var (
 			}
 		}
 	}
+	EnableInfixNotation CompileOption = func(c *CompileConfig) {
+		c.CompileOptions[InfixNotation] = true
+	}
 )
 
 func NewCompileConfig(opts ...CompileOption) *CompileConfig {

--- a/compile.go
+++ b/compile.go
@@ -15,6 +15,7 @@ const (
 	ConstantFolding Option = "constant_folding"
 
 	Debug                 Option = "debug"
+	InfixNotation         Option = "infix_notation"
 	AllowUnknownSelectors Option = "allow_unknown_selectors"
 )
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -979,7 +979,7 @@ func TestRandomExpressions(t *testing.T) {
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = false
+		printProgress = true
 	)
 
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -979,7 +979,7 @@ func TestRandomExpressions(t *testing.T) {
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = true
+		printProgress = false
 	)
 
 	const (

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,40 @@
+package eval
+
+import "fmt"
+
+func ExampleEval() {
+	output, err := Eval(`(+ 1 v1)`, map[string]interface{}{
+		"v1": 1,
+	})
+	if err != nil {
+		fmt.Printf("err: %v", err)
+		return
+	}
+
+	fmt.Printf("%v", output)
+
+	// Output: 2
+}
+
+func ExampleEval_infix() {
+
+	expr := `1 + v2 * (v3 + v5) / v4`
+
+	vals := map[string]interface{}{
+		"v2": 2,
+		"v3": 3,
+		"v4": 4,
+		"v5": 5,
+	}
+	cc := NewCompileConfig(EnableInfixNotation, RegisterSelKeys(vals))
+
+	output, err := Eval(expr, vals, cc)
+	if err != nil {
+		fmt.Printf("err: %v", err)
+		return
+	}
+
+	fmt.Printf("%v", output)
+
+	// Output: 5
+}

--- a/example_text.go
+++ b/example_text.go
@@ -1,0 +1,1 @@
+package eval

--- a/example_text.go
+++ b/example_text.go
@@ -1,1 +1,0 @@
-package eval

--- a/operator.go
+++ b/operator.go
@@ -42,7 +42,6 @@ var (
 		"not": logicNot,
 		"&":   logic{mode: and}.execute,
 		"|":   logic{mode: or}.execute,
-		"^":   logic{mode: xor}.execute,
 		"!":   logicNot,
 
 		// comparison

--- a/operator.go
+++ b/operator.go
@@ -75,6 +75,11 @@ var (
 		// version
 		"version":   versionConvert{mode: version, validLen: 3}.execute,
 		"t_version": versionConvert{mode: toVersion, validLen: 3}.execute,
+
+		// infix notation patch
+		"==": comparisonEquals,
+		"&&": logic{mode: and}.execute,
+		"||": logic{mode: or}.execute,
 	}
 )
 

--- a/parse.go
+++ b/parse.go
@@ -432,7 +432,7 @@ func (p *parser) parseList() (*astNode, error) {
 	if typ != rParen && typ != integer && typ != str {
 		return nil, nil
 	}
-	strs := []string{}
+	strs := make([]string, 0)
 	for j := i + 1; j < len(T); j++ {
 		if T[j].typ == rParen {
 			i = j

--- a/parse_test.go
+++ b/parse_test.go
@@ -61,6 +61,7 @@ func TestLex(t *testing.T) {
 	testCases := []struct {
 		expr   string
 		tokens []token
+		cc     *CompileConfig
 		errMsg string
 	}{
 		{
@@ -218,6 +219,16 @@ func TestLex(t *testing.T) {
 				{typ: ident, val: "abc"},
 				{typ: ident, val: "abc_1"},
 			},
+		},
+
+		{
+			expr: `1 + 2`,
+			tokens: []token{
+				{typ: integer, val: "1"},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "2"},
+			},
+			cc: NewCompileConfig(EnableInfixNotation),
 		},
 
 		{
@@ -441,7 +452,7 @@ func TestLex(t *testing.T) {
 	for _, c := range testCases {
 
 		t.Run(c.expr, func(t *testing.T) {
-			p := &parser{source: c.expr}
+			p := newParser(c.cc, c.expr)
 			err := p.lex()
 			if len(c.errMsg) != 0 {
 				assertErrStrContains(t, err, c.errMsg, c)

--- a/parse_test.go
+++ b/parse_test.go
@@ -1049,6 +1049,50 @@ func TestParseInfixAstTree(t *testing.T) {
 				},
 			},
 		},
+		{
+			expr: `3 + 4 * 2 / ( 1 - 5 ) - 6`,
+			ast: verifyNode{
+				tpy:  operator,
+				data: "-",
+				children: []verifyNode{
+					{
+						tpy:  operator,
+						data: "+",
+						children: []verifyNode{
+							{tpy: constant, data: int64(3)},
+							{
+								tpy:  operator,
+								data: "/",
+								children: []verifyNode{
+									{
+										tpy:  operator,
+										data: "*",
+										children: []verifyNode{
+											{tpy: constant, data: int64(4)},
+											{tpy: constant, data: int64(2)},
+										},
+									},
+									{
+										tpy:  operator,
+										data: "-",
+										children: []verifyNode{
+											{tpy: constant, data: int64(1)},
+											{tpy: constant, data: int64(5)},
+										},
+									},
+								},
+							},
+						},
+					},
+					{tpy: constant, data: int64(6)},
+				},
+			},
+			cc: &CompileConfig{
+				CompileOptions: map[Option]bool{
+					InfixNotation: true,
+				},
+			},
+		},
 	}
 
 	for _, c := range testCases {

--- a/parse_test.go
+++ b/parse_test.go
@@ -983,6 +983,127 @@ func TestParseInfixAstTree(t *testing.T) {
 		},
 
 		{
+			expr: `mod(4, 2) * 3`,
+			ast: verifyNode{
+				tpy:  operator,
+				data: "*",
+				children: []verifyNode{
+					{
+						tpy:  operator,
+						data: "mod",
+						children: []verifyNode{
+							{tpy: constant, data: int64(4)},
+							{tpy: constant, data: int64(2)},
+						},
+					},
+					{tpy: constant, data: int64(3)},
+				},
+			},
+			cc: &CompileConfig{
+				CompileOptions: map[Option]bool{
+					InfixNotation: true,
+				},
+			},
+		},
+
+		{
+			expr: `mod(16 + 2, add(3 + 1, 8)) * 5`,
+			ast: verifyNode{
+				tpy:  operator,
+				data: "*",
+				children: []verifyNode{
+					{
+						tpy:  operator,
+						data: "mod",
+						children: []verifyNode{
+							{
+								tpy:  operator,
+								data: "+",
+								children: []verifyNode{
+									{tpy: constant, data: int64(16)},
+									{tpy: constant, data: int64(2)},
+								},
+							},
+							{
+								tpy:  operator,
+								data: "add",
+								children: []verifyNode{
+									{
+										tpy:  operator,
+										data: "+",
+										children: []verifyNode{
+											{tpy: constant, data: int64(3)},
+											{tpy: constant, data: int64(1)},
+										},
+									},
+									{tpy: constant, data: int64(8)},
+								},
+							},
+						},
+					},
+					{tpy: constant, data: int64(5)},
+				},
+			},
+			cc: &CompileConfig{
+				CompileOptions: map[Option]bool{
+					InfixNotation: true,
+				},
+			},
+		},
+
+		{
+			expr: `1 + 1 = 2 | 4 = 2 + 2 & true`,
+			ast: verifyNode{
+				tpy:  operator,
+				data: "|",
+				children: []verifyNode{
+					{
+						tpy:  operator,
+						data: "=",
+						children: []verifyNode{
+							{
+								tpy:  operator,
+								data: "+",
+								children: []verifyNode{
+									{tpy: constant, data: int64(1)},
+									{tpy: constant, data: int64(1)},
+								},
+							},
+							{tpy: constant, data: int64(2)},
+						},
+					},
+					{
+						tpy:  operator,
+						data: "&",
+						children: []verifyNode{
+							{
+								tpy:  operator,
+								data: "=",
+								children: []verifyNode{
+									{tpy: constant, data: int64(4)},
+									{
+										tpy:  operator,
+										data: "+",
+										children: []verifyNode{
+											{tpy: constant, data: int64(2)},
+											{tpy: constant, data: int64(2)},
+										},
+									},
+								},
+							},
+							{tpy: constant, data: true},
+						},
+					},
+				},
+			},
+			cc: &CompileConfig{
+				CompileOptions: map[Option]bool{
+					InfixNotation: true,
+				},
+			},
+		},
+
+		{
 			expr: `((1 + 2) * 3) / 1`,
 			ast: verifyNode{
 				tpy:  operator,

--- a/parse_test.go
+++ b/parse_test.go
@@ -214,6 +214,37 @@ func TestLex(t *testing.T) {
 		},
 
 		{
+			expr: `a >= 8 && !(b && !e) && mod(c + 6 * f, 10) == 7`,
+			cc:   NewCompileConfig(EnableInfixNotation),
+			tokens: []token{
+				{typ: ident, val: "a"},
+				{typ: ident, val: ">="},
+				{typ: integer, val: "8"},
+				{typ: ident, val: "&&"},
+				{typ: ident, val: "!"},
+				{typ: lParen, val: "("},
+				{typ: ident, val: "b"},
+				{typ: ident, val: "&&"},
+				{typ: ident, val: "!"},
+				{typ: ident, val: "e"},
+				{typ: rParen, val: ")"},
+				{typ: ident, val: "&&"},
+				{typ: ident, val: "mod"},
+				{typ: lParen, val: "("},
+				{typ: ident, val: "c"},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "6"},
+				{typ: ident, val: "*"},
+				{typ: ident, val: "f"},
+				{typ: comma, val: ","},
+				{typ: integer, val: "10"},
+				{typ: rParen, val: ")"},
+				{typ: ident, val: "=="},
+				{typ: integer, val: "7"},
+			},
+		},
+
+		{
 			expr: `(+ -1 1)`,
 			tokens: []token{
 				{typ: lParen, val: "("},

--- a/parse_test.go
+++ b/parse_test.go
@@ -75,6 +75,57 @@ func TestLex(t *testing.T) {
 			},
 		},
 		{
+			expr: `1 + 2`,
+			tokens: []token{
+				{typ: integer, val: "1"},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "2"},
+			},
+		},
+		{
+			expr: `1+2`,
+			tokens: []token{
+				{typ: integer, val: "1"},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "2"},
+			},
+			cc: NewCompileConfig(EnableInfixNotation),
+		},
+		{
+			expr: `1+2 == (3)`,
+			tokens: []token{
+				{typ: integer, val: "1"},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "2"},
+				{typ: ident, val: "=="},
+				{typ: lParen, val: "("},
+				{typ: integer, val: "3"},
+				{typ: rParen, val: ")"},
+			},
+			cc: NewCompileConfig(EnableInfixNotation),
+		},
+		{
+			expr: `1+2==3`,
+			tokens: []token{
+				{typ: integer, val: "1"},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "2"},
+				{typ: ident, val: "=="},
+				{typ: integer, val: "3"},
+			},
+			cc: NewCompileConfig(EnableInfixNotation),
+		},
+		{
+			expr: `(+ -1 1)`,
+			tokens: []token{
+				{typ: lParen, val: "("},
+				{typ: ident, val: "+"},
+				{typ: integer, val: "-1"},
+				{typ: integer, val: "1"},
+				{typ: rParen, val: ")"},
+			},
+		},
+		{
 			expr: `
 ;; expr start
 (+ ;; add
@@ -240,7 +291,7 @@ func TestLex(t *testing.T) {
 
 		{
 			expr:   `"`,
-			errMsg: "can not parse token",
+			errMsg: "unclosed quotes",
 		},
 
 		// complicated expression with a messy format

--- a/util.go
+++ b/util.go
@@ -650,3 +650,22 @@ func DumpTable(expr *Expr, skipDebug ...bool) string {
 
 	return sb.String()
 }
+
+type SelectorKeys struct {
+	SelKey SelectorKey
+	StrKey string
+}
+
+func GetSelectorKeys(e *Expr) []SelectorKeys {
+	res := make([]SelectorKeys, len(e.nodes)/2)
+
+	for _, n := range e.nodes {
+		if n.getNodeType() == selector {
+			res = append(res, SelectorKeys{
+				SelKey: n.selKey,
+				StrKey: n.value.(string),
+			})
+		}
+	}
+	return res
+}


### PR DESCRIPTION
## Summary

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/onheap/eval	2.442s
```

- [x] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16       	56624452	        64.23 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16        	50888629	        64.22 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16      	56396331	        62.29 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16       	52864970	        62.31 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocalRCO-16    	28274929	       125.1 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/local	20.995s
```

- [x] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     37098|     30000|      4526|       172|    2.116s|
|       2 %|       2 %|     63292|     60000|       613|       279|     3.45s|
|       3 %|       3 %|     94265|     90000|      1687|       178|    3.718s|
|       4 %|       4 %|    127618|    120000|      5213|         5|    4.236s|
|       5 %|       5 %|    154122|    150000|      1532|       190|    3.943s|
|       6 %|       6 %|    183687|    180000|      1282|         5|    3.884s|
|       7 %|       7 %|    212475|    210000|        65|        10|    4.118s|
|       8 %|       8 %|    242314|    240000|         0|         0|    4.206s|
|       9 %|       9 %|    272670|    270000|       204|        66|    4.181s|
|      10 %|      10 %|    304423|    300000|      2010|        13|    4.415s|
|      11 %|      11 %|    334456|    330000|      2053|         3|    4.304s|
|      12 %|      12 %|    362504|    360000|       104|         0|     4.57s|
|      13 %|      13 %|    392400|    390000|         0|         1|    4.421s|
|      14 %|      14 %|    422352|    420000|         0|         0|    4.431s|
|      15 %|      15 %|    452772|    450000|         0|       374|     4.33s|
|      16 %|      16 %|    483343|    480000|       744|       199|    4.176s|
|      17 %|      17 %|    512543|    510000|        65|        78|    4.382s|
|      18 %|      18 %|    542928|    540000|         0|       535|    4.574s|
|      19 %|      19 %|    573054|    570000|       517|       137|    4.249s|
|      20 %|      20 %|    603592|    600000|      1147|        45|    4.376s|
|      21 %|      21 %|    633016|    630000|       477|       139|    4.144s|
|      22 %|      22 %|    662763|    660000|       210|       153|    4.202s|
|      23 %|      23 %|    692617|    690000|       106|       111|     4.15s|
|      24 %|      24 %|    722410|    720000|         3|         7|    4.201s|
|      25 %|      25 %|    753287|    750000|       796|        91|    4.236s|
|      26 %|      26 %|    782802|    780000|       386|        16|    4.664s|
|      27 %|      27 %|    812686|    810000|       206|        80|    4.872s|
|      28 %|      28 %|    843152|    840000|        33|       719|    4.472s|
|      29 %|      29 %|    874443|    870000|      1962|        81|    4.621s|
|      30 %|      30 %|    902635|    900000|       225|        10|    4.249s|
|      31 %|      31 %|    932633|    930000|       118|       115|    4.426s|
|      32 %|      32 %|    962850|    960000|       425|        25|    4.281s|
|      33 %|      33 %|    992634|    990000|       223|        11|    4.251s|
|      34 %|      34 %|   1022838|   1020000|       256|       182|    4.389s|
|      35 %|      35 %|   1053585|   1050000|      1164|        21|    4.474s|
|      36 %|      36 %|   1082464|   1080000|        28|        36|    4.491s|
|      37 %|      37 %|   1112734|   1110000|       331|         3|    4.476s|
|      38 %|      38 %|   1142663|   1140000|       261|         2|    4.663s|
|      39 %|      39 %|   1172656|   1170000|       140|       116|    4.656s|
|      40 %|      40 %|   1202460|   1200000|         0|        64|    4.546s|
|      41 %|      41 %|   1232601|   1230000|       201|         0|     4.62s|
|      42 %|      42 %|   1262452|   1260000|        14|        38|    4.536s|
|      43 %|      43 %|   1292456|   1290000|        14|        42|    4.526s|
|      44 %|      44 %|   1322486|   1320000|        45|        41|    4.495s|
|      45 %|      45 %|   1352606|   1350000|       205|         1|     4.42s|
|      46 %|      46 %|   1382733|   1380000|       238|        95|     4.53s|
|      47 %|      47 %|   1412594|   1410000|       118|        76|    5.001s|
|      48 %|      48 %|   1442589|   1440000|        98|        91|    4.505s|
|      49 %|      49 %|   1472438|   1470000|        31|         7|    4.478s|
|      50 %|      50 %|   1502643|   1500000|       237|         6|    4.538s|
|      51 %|      51 %|   1533001|   1530000|       584|        17|    4.488s|
|      52 %|      52 %|   1562730|   1560000|       234|        96|    4.739s|
|      53 %|      53 %|   1592850|   1590000|       420|        30|    4.621s|
|      54 %|      54 %|   1622481|   1620000|        70|        11|    4.555s|
|      55 %|      55 %|   1652530|   1650000|        61|        69|    4.638s|
|      56 %|      56 %|   1682669|   1680000|       185|        84|    4.634s|
|      57 %|      57 %|   1712738|   1710000|       276|        62|      4.5s|
|      58 %|      58 %|   1742837|   1740000|       375|        62|    4.608s|
|      59 %|      59 %|   1773324|   1770000|       922|         2|    4.478s|
|      60 %|      60 %|   1802779|   1800000|       203|       176|    4.441s|
|      61 %|      61 %|   1833043|   1830000|       531|       112|    4.597s|
|      62 %|      62 %|   1863741|   1860000|      1335|         6|    4.556s|
|      63 %|      63 %|   1892575|   1890000|       170|         5|    4.489s|
|      64 %|      64 %|   1922468|   1920000|        13|        55|    4.591s|
|      65 %|      65 %|   1952611|   1950000|       206|         5|      4.6s|
|      66 %|      66 %|   1983044|   1980000|       165|       479|    4.693s|
|      67 %|      67 %|   2012408|   2010000|         0|        12|    4.526s|
|      68 %|      68 %|   2043351|   2040000|       469|       482|    4.621s|
|      69 %|      69 %|   2076539|   2070000|      4076|        63|    2.689s|
|      70 %|      70 %|   2102581|   2100000|         0|       185|    4.547s|
|      71 %|      71 %|   2132645|   2130000|       153|        92|    4.585s|
|      72 %|      72 %|   2162701|   2160000|       272|        29|    4.586s|
|      73 %|      73 %|   2192556|   2190000|        60|        96|    4.595s|
|      74 %|      74 %|   2223801|   2220000|      1380|        21|    4.564s|
|      75 %|      75 %|   2253293|   2250000|       767|       126|    4.638s|
|      76 %|      76 %|   2282627|   2280000|       186|        41|    5.755s|
|      77 %|      77 %|   2312639|   2310000|       173|        66|    4.945s|
|      78 %|      78 %|   2342423|   2340000|        19|         4|    4.796s|
|      79 %|      79 %|   2372464|   2370000|        63|         1|    5.152s|
|      80 %|      80 %|   2403588|   2400000|      1167|        21|    4.925s|
|      81 %|      81 %|   2432481|   2430000|        56|        25|    4.755s|
|      82 %|      82 %|   2463166|   2460000|       733|        33|    4.791s|
|      83 %|      83 %|   2492838|   2490000|       226|       212|    4.794s|
|      84 %|      84 %|   2523197|   2520000|       601|       196|    4.679s|
|      85 %|      85 %|   2552475|   2550000|        66|         9|    4.479s|
|      86 %|      86 %|   2582564|   2580000|       155|         9|    4.641s|
|      87 %|      87 %|   2612831|   2610000|       387|        44|    4.654s|
|      88 %|      88 %|   2642622|   2640000|       127|        95|    4.761s|
|      89 %|      89 %|   2672413|   2670000|         0|        14|    4.742s|
|      90 %|      90 %|   2702725|   2700000|       230|        95|    4.781s|
|      91 %|      91 %|   2733626|   2730000|      1197|        29|    5.148s|
|      92 %|      92 %|   2764942|   2760000|      2427|       115|    5.097s|
|      93 %|      93 %|   2792494|   2790000|        32|        62|    5.041s|
|      94 %|      94 %|   2822986|   2820000|       421|       165|    4.954s|
|      95 %|      95 %|   2852563|   2850000|        28|       135|    4.764s|
|      96 %|      96 %|   2883808|   2880000|      1307|       101|    4.902s|
|      97 %|      97 %|   2913837|   2910000|      1437|         0|    4.734s|
|      98 %|      98 %|   2944359|   2940000|      1952|         7|    4.884s|
|      99 %|      99 %|   2972397|   2970000|         0|         0|    4.886s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    4.944s|
PASS
ok  	github.com/onheap/eval	454.483s
```

## Reviewers
@larry618