### PR TITLE
[compile] optimize reduce nesting

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -132,10 +132,9 @@ func TestGetCosts(t *testing.T) {
 
 func TestOptimizeConstantFolding(t *testing.T) {
 	testCases := []struct {
-		cc     *CompileConfig
-		expr   string
-		ast    verifyNode
-		errMsg string
+		cc   *CompileConfig
+		expr string
+		ast  verifyNode
 	}{
 		{
 			expr: `(+ 1 1)`,
@@ -353,12 +352,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 	for _, c := range testCases {
 		ast, cc, err := newParser(c.cc, c.expr).parse()
 		assertNil(t, err, c)
-		err = optimizeConstantFolding(cc, ast)
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
-
+		optimizeConstantFolding(cc, ast)
 		assertAstTreeIdentical(t, ast, c.ast, c)
 	}
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -1078,11 +1078,11 @@ func TestExpr_EvalRCO(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 10000
+		size          = 3000000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = false
+		printProgress = true
 	)
 
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -1078,11 +1078,11 @@ func TestExpr_EvalRCO(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = true
+		printProgress = false
 	)
 
 	const (

--- a/parse.go
+++ b/parse.go
@@ -854,16 +854,17 @@ func (p *parser) parseConfig() error {
 				pair[i] = strings.TrimSpace(pair[i])
 			}
 
+			option := Option(pair[0])
 			enabled, err := strconv.ParseBool(pair[1])
 			if err != nil {
 				return p.errWithToken(fmt.Errorf("invalid config value %s, err %w", s, err), t)
 			}
-			switch option := Option(pair[0]); option {
-			case Optimize: // switch all optimizations
-				for _, opt := range AllOptimizations {
+			switch {
+			case option == Optimize: // switch all optimizations
+				for _, opt := range optimizations {
 					p.conf.CompileOptions[opt] = enabled
 				}
-			case Reordering, FastEvaluation, ConstantFolding:
+			case optimizerMap[option] != nil:
 				p.conf.CompileOptions[option] = enabled
 			default:
 				return p.errWithToken(fmt.Errorf("unsupported compile config %s", s), t)


### PR DESCRIPTION
## Summary

This PR updates compile to reduce nesting bool operators. it similar with the optimization _[flatten-ands-and-ors](flatten-ands-and-ors)_ of _Facebook Velox_

![image](https://user-images.githubusercontent.com/10290006/188320721-d3a33b39-ad1f-44a4-98d4-adf1e0f4a12d.png)

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/onheap/eval	1.726s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem

goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16       	50914374	        64.73 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16        	52488130	        63.06 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16      	52575392	        65.21 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16       	53836501	        63.64 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocalRCO-16    	26803562	       130.8 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/local	18.030s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     40035|     30000|      7513|       122|    2.299s|
|       2 %|       2 %|     70635|     60000|      8234|         1|     3.72s|
|       3 %|       3 %|    102392|     90000|      9950|        45|    4.111s|
|       4 %|       4 %|    122519|    120000|         0|       120|    3.944s|
|       5 %|       5 %|    152544|    150000|        89|        55|    4.144s|
|       6 %|       6 %|    182512|    180000|        26|        86|    4.047s|
|       7 %|       7 %|    212580|    210000|        26|       154|    4.092s|
|       8 %|       8 %|    243023|    240000|       336|       287|    4.255s|
|       9 %|       9 %|    272571|    270000|        50|       121|    3.967s|
|      10 %|      10 %|    302641|    300000|       103|       138|     4.19s|
|      11 %|      11 %|    332836|    330000|       408|        28|    4.122s|
|      12 %|      12 %|    362728|    360000|       214|       114|    4.109s|
|      13 %|      13 %|    392773|    390000|       160|       213|    4.246s|
|      14 %|      14 %|    422710|    420000|       308|         2|     4.09s|
|      15 %|      15 %|    452427|    450000|         0|        60|     4.06s|
|      16 %|      16 %|    482447|    480000|        45|         2|    4.132s|
|      17 %|      17 %|    512655|    510000|        14|       241|    4.136s|
|      18 %|      18 %|    544814|    540000|      2363|        51|    4.112s|
|      19 %|      19 %|    572968|    570000|       370|       198|     4.08s|
|      20 %|      20 %|    602608|    600000|         0|       220|    4.012s|
|      21 %|      21 %|    632816|    630000|       416|         0|    4.135s|
|      22 %|      22 %|    663230|    660000|       603|       227|    4.142s|
|      23 %|      23 %|    693325|    690000|       911|        14|    4.285s|
|      24 %|      24 %|    723447|    720000|       833|       214|    4.606s|
|      25 %|      25 %|    752460|    750000|        43|        17|    4.654s|
|      26 %|      26 %|    782402|    780000|         0|         5|    4.626s|
|      27 %|      27 %|    812839|    810000|       427|        12|    4.455s|
|      28 %|      28 %|    843715|    840000|      1284|        31|    4.669s|
|      29 %|      29 %|    872472|    870000|        60|        12|    4.548s|
|      30 %|      30 %|    902589|    900000|       166|        23|    4.715s|
|      31 %|      31 %|    932793|    930000|       273|       120|    4.435s|
|      32 %|      32 %|    962524|    960000|        82|        42|    4.641s|
|      33 %|      33 %|    993676|    990000|      1251|        25|    4.411s|
|      34 %|      34 %|   1024804|   1020000|      2153|       251|    4.564s|
|      35 %|      35 %|   1052415|   1050000|        15|         0|    4.388s|
|      36 %|      36 %|   1082669|   1080000|       164|       105|    4.752s|
|      37 %|      37 %|   1113917|   1110000|      1462|        55|    4.556s|
|      38 %|      38 %|   1149998|   1140000|      7597|         1|    2.677s|
|      39 %|      39 %|   1172940|   1170000|       380|       160|    4.185s|
|      40 %|      40 %|   1210582|   1200000|      8182|         0|    4.665s|
|      41 %|      41 %|   1235534|   1230000|      3057|        77|    4.308s|
|      42 %|      42 %|   1262540|   1260000|       113|        27|    4.284s|
|      43 %|      43 %|   1292868|   1290000|       431|        37|    4.457s|
|      44 %|      44 %|   1324198|   1320000|      1751|        47|    4.594s|
|      45 %|      45 %|   1352526|   1350000|        78|        48|     4.43s|
|      46 %|      46 %|   1382813|   1380000|       411|         2|    4.636s|
|      47 %|      47 %|   1417305|   1410000|      4885|        20|    2.673s|
|      48 %|      48 %|   1442579|   1440000|       157|        22|    4.384s|
|      49 %|      49 %|   1473773|   1470000|      1347|        26|    4.426s|
|      50 %|      50 %|   1502481|   1500000|        47|        34|    4.483s|
|      51 %|      51 %|   1533961|   1530000|      1532|        29|     4.61s|
|      52 %|      52 %|   1563435|   1560000|       945|        90|    4.581s|
|      53 %|      53 %|   1592615|   1590000|        71|       144|    4.609s|
|      54 %|      54 %|   1622471|   1620000|        34|        37|    4.447s|
|      55 %|      55 %|   1652511|   1650000|        67|        44|    4.487s|
|      56 %|      56 %|   1682567|   1680000|       106|        61|    4.449s|
|      57 %|      57 %|   1713062|   1710000|       371|       291|    4.603s|
|      58 %|      58 %|   1743482|   1740000|       896|       186|    4.503s|
|      59 %|      59 %|   1772407|   1770000|         0|         8|    4.555s|
|      60 %|      60 %|   1802513|   1800000|        94|        19|    4.536s|
|      61 %|      61 %|   1832630|   1830000|       230|         0|    4.449s|
|      62 %|      62 %|   1863047|   1860000|       533|       114|    4.412s|
|      63 %|      63 %|   1895272|   1890000|      2706|       166|     4.58s|
|      64 %|      64 %|   1922414|   1920000|         2|        12|    4.314s|
|      65 %|      65 %|   1952547|   1950000|        36|       111|    4.499s|
|      66 %|      66 %|   1983200|   1980000|       735|        65|    4.704s|
|      67 %|      67 %|   2012616|   2010000|       173|        43|      4.5s|
|      68 %|      68 %|   2045466|   2040000|      3030|        36|    4.619s|
|      69 %|      69 %|   2072767|   2070000|        51|       317|    4.511s|
|      70 %|      70 %|   2103303|   2100000|        19|       884|    4.602s|
|      71 %|      71 %|   2132466|   2130000|         4|        62|    4.415s|
|      72 %|      72 %|   2162542|   2160000|        80|        62|    4.541s|
|      73 %|      73 %|   2192927|   2190000|       390|       137|    4.448s|
|      74 %|      74 %|   2222390|   2220000|         0|         0|    4.403s|
|      75 %|      75 %|   2252582|   2250000|       174|         8|    4.394s|
|      76 %|      76 %|   2282601|   2280000|        18|       183|    4.424s|
|      77 %|      77 %|   2312698|   2310000|       127|       171|    4.678s|
|      78 %|      78 %|   2342428|   2340000|        19|         9|    4.528s|
|      79 %|      79 %|   2372886|   2370000|       396|        90|    4.617s|
|      80 %|      80 %|   2402855|   2400000|       239|       216|     4.51s|
|      81 %|      81 %|   2432839|   2430000|       426|        13|    4.561s|
|      82 %|      82 %|   2462582|   2460000|       130|        52|    4.627s|
|      83 %|      83 %|   2492690|   2490000|        72|       218|     4.42s|
|      84 %|      84 %|   2522710|   2520000|       297|        14|    4.475s|
|      85 %|      85 %|   2552843|   2550000|       437|         6|    4.411s|
|      86 %|      86 %|   2584212|   2580000|      1651|       161|    4.469s|
|      87 %|      87 %|   2612421|   2610000|         0|        24|    4.549s|
|      88 %|      88 %|   2642741|   2640000|       291|        50|    4.549s|
|      89 %|      89 %|   2672650|   2670000|       186|        64|    4.659s|
|      90 %|      90 %|   2703019|   2700000|       617|         2|    4.557s|
|      91 %|      91 %|   2732650|   2730000|       136|       114|    4.429s|
|      92 %|      92 %|   2762532|   2760000|        24|       108|    4.584s|
|      93 %|      93 %|   2792758|   2790000|        58|       300|    4.626s|
|      94 %|      94 %|   2822786|   2820000|       125|       261|    4.516s|
|      95 %|      95 %|   2852595|   2850000|        88|       107|    4.338s|
|      96 %|      96 %|   2882457|   2880000|        48|         9|    4.423s|
|      97 %|      97 %|   2912715|   2910000|       236|        79|    4.411s|
|      98 %|      98 %|   2942520|   2940000|       111|         9|    4.934s|
|      99 %|      99 %|   2972685|   2970000|       260|        25|    4.904s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    4.751s|
PASS
ok  	github.com/onheap/eval	443.138s
```

## Reviewers
@onheap