### PR TITLE
[parse] enable dot in the parsing identifier

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -350,10 +350,12 @@ func TestOptimizeConstantFolding(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		ast, cc, err := newParser(c.cc, c.expr).parse()
-		assertNil(t, err, c)
-		optimizeConstantFolding(cc, ast)
-		assertAstTreeIdentical(t, ast, c.ast, c)
+		t.Run(c.expr, func(t *testing.T) {
+			ast, cc, err := newParser(c.cc, c.expr).parse()
+			assertNil(t, err, c)
+			optimizeConstantFolding(cc, ast)
+			assertAstTreeIdentical(t, ast, c.ast, c)
+		})
 	}
 }
 
@@ -541,16 +543,19 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		ast, cc, err := newParser(c.cc, c.expr).parse()
-		assertNil(t, err)
 
-		optimizeFastEvaluation(cc, ast)
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
+		t.Run(c.expr, func(t *testing.T) {
+			ast, cc, err := newParser(c.cc, c.expr).parse()
+			assertNil(t, err)
 
-		assertAstTreeIdentical(t, ast, c.ast, c)
+			optimizeFastEvaluation(cc, ast)
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+				return
+			}
+
+			assertAstTreeIdentical(t, ast, c.ast, c)
+		})
 	}
 }
 
@@ -769,21 +774,23 @@ func TestReordering(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		ast, cc, err := newParser(c.cc, c.expr).parse()
-		assertNil(t, err)
+		t.Run(c.expr, func(t *testing.T) {
+			ast, cc, err := newParser(c.cc, c.expr).parse()
+			assertNil(t, err)
 
-		if c.fastEval {
-			optimizeFastEvaluation(cc, ast)
-		}
+			if c.fastEval {
+				optimizeFastEvaluation(cc, ast)
+			}
 
-		calculateNodeCosts(cc, ast)
-		optimizeReordering(cc, ast)
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
+			calculateNodeCosts(cc, ast)
+			optimizeReordering(cc, ast)
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+				return
+			}
 
-		assertAstTreeIdentical(t, ast, c.ast, c)
+			assertAstTreeIdentical(t, ast, c.ast, c)
+		})
 	}
 
 }
@@ -938,16 +945,17 @@ func TestOptimize(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		ast, cc, err := newParser(c.cc, c.expr).parse()
-		assertNil(t, err)
+		t.Run(c.expr, func(t *testing.T) {
+			ast, cc, err := newParser(c.cc, c.expr).parse()
+			assertNil(t, err)
 
-		optimize(cc, ast)
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
+			optimize(cc, ast)
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+			}
 
-		assertAstTreeIdentical(t, ast, c.ast, c)
+			assertAstTreeIdentical(t, ast, c.ast, c)
+		})
 	}
 }
 
@@ -1026,22 +1034,24 @@ func TestCheck(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		ast, cc, err := newParser(c.cc, c.expr).parse()
-		assertNil(t, err)
+		t.Run(c.expr, func(t *testing.T) {
+			ast, cc, err := newParser(c.cc, c.expr).parse()
+			assertNil(t, err)
 
-		if c.optimize {
-			optimize(cc, ast)
-		}
+			if c.optimize {
+				optimize(cc, ast)
+			}
 
-		res := check(ast)
+			res := check(ast)
 
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, res.err, c.errMsg, c)
-			continue
-		}
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, res.err, c.errMsg, c)
+				return
+			}
 
-		assertNil(t, res.err, c)
-		assertEquals(t, res.size, c.size, c)
+			assertNil(t, res.err, c)
+			assertEquals(t, res.size, c.size, c)
+		})
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -190,7 +190,7 @@ func (e *Expr) Eval(ctx *Ctx) (res Value, err error) {
 	return os[0], nil
 }
 
-func (e *Expr) EvalRCO(ctx *Ctx) (res Value, err error) {
+func (e *Expr) TryEval(ctx *Ctx) (res Value, err error) {
 	var (
 		nodes = e.nodes
 		size  = int16(len(nodes))

--- a/engine_test.go
+++ b/engine_test.go
@@ -638,7 +638,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 	}
 }
 
-func TestExpr_EvalRCO(t *testing.T) {
+func TestExpr_TryEval(t *testing.T) {
 	const debugMode = false
 
 	type optimizeLevel int
@@ -1078,11 +1078,11 @@ func TestExpr_EvalRCO(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = true
+		printProgress = false
 	)
 
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -461,7 +461,7 @@ func TestExpr_Eval(t *testing.T) {
 			}
 
 			// eval with remote call optimization
-			rcoRes, err := expr.EvalRCO(ctx)
+			rcoRes, err := expr.TryEval(ctx)
 			assertNil(t, err)
 
 			if c.want != nil {
@@ -1062,7 +1062,7 @@ func TestExpr_EvalRCO(t *testing.T) {
 				fmt.Println(DumpTable(expr))
 			}
 
-			res, err := expr.EvalRCO(ctx)
+			res, err := expr.TryEval(ctx)
 			assertNil(t, err)
 
 			if debugMode {
@@ -1078,11 +1078,11 @@ func TestExpr_EvalRCO(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 10000
+		size          = 3000000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = false
+		printProgress = true
 	)
 
 	const (
@@ -1201,7 +1201,7 @@ func TestRandomExpressions(t *testing.T) {
 
 				ctx := NewCtxWithMap(cc, valMap)
 				if c.rco {
-					c.got, c.err = expr.EvalRCO(ctx)
+					c.got, c.err = expr.TryEval(ctx)
 				} else {
 					c.got, c.err = expr.Eval(ctx)
 				}

--- a/parse.go
+++ b/parse.go
@@ -147,7 +147,7 @@ func (p *parser) lex() error {
 				if unicode.IsLetter(r) {
 					continue
 				}
-				if r == '_' {
+				if r == '_' || r == '.' {
 					continue
 				}
 

--- a/parse.go
+++ b/parse.go
@@ -138,16 +138,26 @@ func (p *parser) lex() error {
 			return err == nil
 		}
 		isValidIdent = func(s string) bool {
-			for idx, r := range []rune(s) {
+			prevDotIdx := -1
+			runes := []rune(s)
+			lastIdx := len(runes) - 1
+			for idx, r := range runes {
+				if unicode.IsLetter(r) {
+					continue
+				}
+				if r == '_' {
+					continue
+				}
 				if unicode.IsNumber(r) {
 					if idx != 0 {
 						continue
 					}
 				}
-				if unicode.IsLetter(r) {
-					continue
-				}
-				if r == '_' || r == '.' {
+				if r == '.' {
+					if idx == prevDotIdx+1 || idx == 0 || idx == lastIdx {
+						return false
+					}
+					prevDotIdx = idx
 					continue
 				}
 

--- a/parse.go
+++ b/parse.go
@@ -293,6 +293,10 @@ func (p *parser) check() error {
 		}
 	}
 
+	if parenCnt != 0 {
+		return p.parenUnmatchedErr(0)
+	}
+
 	return nil
 }
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -245,6 +245,16 @@ func TestLex(t *testing.T) {
 		},
 
 		{
+			expr: `(and ()`,
+			tokens: []token{
+				{typ: lParen, val: "("},
+				{typ: ident, val: "and"},
+				{typ: lParen, val: "("},
+				{typ: rParen, val: ")"},
+			},
+		},
+
+		{
 			expr: `(+ -1 1)`,
 			tokens: []token{
 				{typ: lParen, val: "("},

--- a/parse_test.go
+++ b/parse_test.go
@@ -264,6 +264,17 @@ func TestLex(t *testing.T) {
 				{typ: rParen, val: ")"},
 			},
 		},
+
+		{
+			expr: `(math.Sub startDate.Year user.Birthdate.Year)`,
+			tokens: []token{
+				{typ: lParen, val: "("},
+				{typ: ident, val: "math.Sub"},
+				{typ: ident, val: "startDate.Year"},
+				{typ: ident, val: "user.Birthdate.Year"},
+				{typ: rParen, val: ")"},
+			},
+		},
 		{
 			expr: `
 ;; expr start
@@ -435,6 +446,26 @@ func TestLex(t *testing.T) {
 
 		{
 			expr:   `!3`,
+			errMsg: "can not parse token",
+		},
+
+		{
+			expr:   `(math.Sub. 1 2)`,
+			errMsg: "can not parse token",
+		},
+
+		{
+			expr:   `(- .def 2)`,
+			errMsg: "can not parse token",
+		},
+
+		{
+			expr:   `(- def. 2)`,
+			errMsg: "can not parse token",
+		},
+
+		{
+			expr:   `(- d..f 2)`,
 			errMsg: "can not parse token",
 		},
 
@@ -791,6 +822,23 @@ func TestParseAstTree(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			expr: `(math.Abs 1 abc.def.ijk)`,
+			cc: NewCompileConfig(RegisterVals(map[string]interface{}{
+				"math.Abs":    Operator(nil), // just a placeholder
+				"abc.def.ijk": -1,
+			})),
+			ast: verifyNode{
+				tpy:  operator,
+				data: "math.Abs",
+				children: []verifyNode{
+					{tpy: constant, data: int64(1)},
+					{tpy: selector, data: "abc.def.ijk"},
+				},
+			},
+		},
+
 		{
 			expr: `
 (<

--- a/util_test.go
+++ b/util_test.go
@@ -315,7 +315,7 @@ func TestGenerateRandomExpr_RCO(t *testing.T) {
 
 		assertNil(t, err)
 
-		got, err := expr.EvalRCO(ctx)
+		got, err := expr.TryEval(ctx)
 		if err != nil {
 			fmt.Println(GenerateTestCase(genRes.Expr, genRes.Res, valMap))
 			t.Fatalf("assertNil failed, got: %+v\n", err)


### PR DESCRIPTION
## Summary
This PR does the following things.
1. enable dot in the parsing identifier
2. add index checking to the parser
3. add unit tests

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/onheap/eval	2.238s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16       	47684266	        64.87 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16        	51976588	        64.38 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16      	52965994	        64.06 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16       	53774517	        64.52 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocalRCO-16    	27414420	       128.1 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/local	17.973s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     39465|     30000|      6999|        66|    2.203s|
|       2 %|       2 %|     63212|     60000|       789|        23|    3.894s|
|       3 %|       3 %|     92786|     90000|       235|       151|    4.784s|
|       4 %|       4 %|    123835|    120000|      1431|         4|    4.402s|
|       5 %|       5 %|    152413|    150000|         8|         5|    3.994s|
|       6 %|       6 %|    184522|    180000|      2106|        16|    4.309s|
|       7 %|       7 %|    212511|    210000|       111|         0|     4.13s|
|       8 %|       8 %|    242408|    240000|         0|        15|    4.274s|
|       9 %|       9 %|    272402|    270000|         0|         2|    4.292s|
|      10 %|      10 %|    302704|    300000|       216|        88|     4.31s|
|      11 %|      11 %|    332458|    330000|        32|        26|    4.278s|
|      12 %|      12 %|    362670|    360000|       269|         1|     4.44s|
|      13 %|      13 %|    392555|    390000|        56|        99|    4.322s|
|      14 %|      14 %|    422607|    420000|       147|        60|    4.296s|
|      15 %|      15 %|    453619|    450000|      1121|        98|     4.39s|
|      16 %|      16 %|    483959|    480000|      1493|        66|     4.52s|
|      17 %|      17 %|    513242|    510000|       702|       140|    4.612s|
|      18 %|      18 %|    542770|    540000|       351|        19|     4.48s|
|      19 %|      19 %|    572704|    570000|       253|        51|    4.457s|
|      20 %|      20 %|    602971|    600000|       532|        39|    4.545s|
|      21 %|      21 %|    632443|    630000|        39|         4|    4.704s|
|      22 %|      22 %|    663010|    660000|       534|        76|    4.525s|
|      23 %|      23 %|    692550|    690000|        31|       119|    4.413s|
|      24 %|      24 %|    722502|    720000|        62|        40|    4.407s|
|      25 %|      25 %|    752761|    750000|       190|       171|    4.383s|
|      26 %|      26 %|    783045|    780000|       521|       124|    4.289s|
|      27 %|      27 %|    812422|    810000|        12|        10|    4.356s|
|      28 %|      28 %|    842797|    840000|       381|        16|    4.321s|
|      29 %|      29 %|    872465|    870000|         2|        63|    4.371s|
|      30 %|      30 %|    902631|    900000|       220|        11|    4.293s|
|      31 %|      31 %|    932425|    930000|        12|        13|    4.234s|
|      32 %|      32 %|    963742|    960000|      1319|        23|    4.373s|
|      33 %|      33 %|    992480|    990000|         4|        76|    4.211s|
|      34 %|      34 %|   1023995|   1020000|      1572|        23|    4.325s|
|      35 %|      35 %|   1052877|   1050000|       416|        61|    4.494s|
|      36 %|      36 %|   1082414|   1080000|         0|        18|    4.327s|
|      37 %|      37 %|   1112613|   1110000|       101|       112|    4.599s|
|      38 %|      38 %|   1143037|   1140000|       522|       115|    4.753s|
|      39 %|      39 %|   1172504|   1170000|         0|       107|    4.744s|
|      40 %|      40 %|   1202586|   1200000|        80|       106|    4.782s|
|      41 %|      41 %|   1232486|   1230000|         0|        89|    4.942s|
|      42 %|      42 %|   1262452|   1260000|         0|        59|    4.692s|
|      43 %|      43 %|   1293921|   1290000|      1311|       210|    4.609s|
|      44 %|      44 %|   1322499|   1320000|        83|        16|    4.519s|
|      45 %|      45 %|   1353656|   1350000|      1055|       201|    4.748s|
|      46 %|      46 %|   1383527|   1380000|       188|       939|    4.691s|
|      47 %|      47 %|   1412550|   1410000|        86|        64|    4.404s|
|      48 %|      48 %|   1442545|   1440000|       115|        30|     4.79s|
|      49 %|      49 %|   1473491|   1470000|      1053|        38|    4.775s|
|      50 %|      50 %|   1505375|   1500000|      2784|       191|    4.708s|
|      51 %|      51 %|   1534713|   1530000|      2180|       133|    4.511s|
|      52 %|      52 %|   1562797|   1560000|       355|        42|    4.365s|
|      53 %|      53 %|   1592799|   1590000|       390|         9|    4.456s|
|      54 %|      54 %|   1623171|   1620000|        23|       748|    4.675s|
|      55 %|      55 %|   1652473|   1650000|        67|         6|    4.643s|
|      56 %|      56 %|   1682365|   1680000|         0|        23|    4.728s|
|      57 %|      57 %|   1712413|   1710000|        10|         3|    4.598s|
|      58 %|      58 %|   1742734|   1740000|       106|       228|    4.637s|
|      59 %|      59 %|   1772466|   1770000|        64|         2|    4.578s|
|      60 %|      60 %|   1802757|   1800000|       356|         1|    4.614s|
|      61 %|      61 %|   1832724|   1830000|       154|       170|    4.703s|
|      62 %|      62 %|   1862503|   1860000|        53|        50|    4.592s|
|      63 %|      63 %|   1892364|   1890000|         0|         0|    4.815s|
|      64 %|      64 %|   1922626|   1920000|       105|       121|    4.818s|
|      65 %|      65 %|   1952933|   1950000|       254|       279|    4.842s|
|      66 %|      66 %|   1982502|   1980000|         0|       105|    4.652s|
|      67 %|      67 %|   2012771|   2010000|       275|        96|    4.589s|
|      68 %|      68 %|   2042671|   2040000|       269|         2|    4.646s|
|      69 %|      69 %|   2072388|   2070000|         0|         0|    4.671s|
|      70 %|      70 %|   2102595|   2100000|        90|       105|     4.68s|
|      71 %|      71 %|   2132559|   2130000|       158|         1|    5.043s|
|      72 %|      72 %|   2162761|   2160000|       213|       148|    4.729s|
|      73 %|      73 %|   2192385|   2190000|         0|         0|    4.664s|
|      74 %|      74 %|   2222492|   2220000|        56|        36|    4.645s|
|      75 %|      75 %|   2252445|   2250000|        24|        21|    4.608s|
|      76 %|      76 %|   2282812|   2280000|       311|       101|    4.676s|
|      77 %|      77 %|   2312747|   2310000|       253|        94|    4.622s|
|      78 %|      78 %|   2342391|   2340000|         0|         0|    4.534s|
|      79 %|      79 %|   2374059|   2370000|      1632|        27|    4.664s|
|      80 %|      80 %|   2404120|   2400000|      1695|        25|    4.818s|
|      81 %|      81 %|   2436390|   2430000|      3911|        79|    4.814s|
|      82 %|      82 %|   2462954|   2460000|       546|         8|    4.732s|
|      83 %|      83 %|   2493111|   2490000|       199|       512|     5.08s|
|      84 %|      84 %|   2522842|   2520000|       434|         8|    4.724s|
|      85 %|      85 %|   2552687|   2550000|       278|         9|    4.562s|
|      86 %|      86 %|   2583482|   2580000|      1040|        42|    4.567s|
|      87 %|      87 %|   2612555|   2610000|       106|        49|    4.818s|
|      88 %|      88 %|   2642735|   2640000|       136|       199|    4.885s|
|      89 %|      89 %|   2672891|   2670000|       437|        54|    4.652s|
|      90 %|      90 %|   2702733|   2700000|       166|       167|    4.783s|
|      91 %|      91 %|   2732540|   2730000|        82|        58|    4.804s|
|      92 %|      92 %|   2762989|   2760000|       589|         0|    4.879s|
|      93 %|      93 %|   2792516|   2790000|        63|        53|    4.822s|
|      94 %|      94 %|   2822449|   2820000|        24|        25|    4.874s|
|      95 %|      95 %|   2852763|   2850000|       256|       107|    4.943s|
|      96 %|      96 %|   2882464|   2880000|        38|        26|    4.727s|
|      97 %|      97 %|   2912386|   2910000|         0|         0|    4.656s|
|      98 %|      98 %|   2942387|   2940000|         0|         0|    4.548s|
|      99 %|      99 %|   2972825|   2970000|       387|        38|    4.741s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.666s|
PASS
ok  	github.com/onheap/eval	459.172s
```

## Reviewers
@onheap