### PR TITLE
[engine] [compile] event channel

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -133,6 +133,16 @@ func (cc *CompileConfig) getCosts(nodeType uint8, nodeName string) int {
 		operatorNode = "operator"
 	)
 
+	// want positive value to short-circuit (use subexpression in OR)
+	if v, exist := cc.CostsMap["+"+nodeName]; exist {
+		return v
+	}
+
+	// want negative result to short-circuit (use subexpression in AND)
+	if v, exist := cc.CostsMap["-"+nodeName]; exist {
+		return v
+	}
+
 	if v, exist := cc.CostsMap[nodeName]; exist {
 		return v
 	}

--- a/compile.go
+++ b/compile.go
@@ -137,16 +137,6 @@ func (cc *CompileConfig) getCosts(nodeType uint8, nodeName string) int {
 		operatorNode = "operator"
 	)
 
-	// want positive value to short-circuit (use subexpression in OR)
-	if v, exist := cc.CostsMap["+"+nodeName]; exist {
-		return v
-	}
-
-	// want negative result to short-circuit (use subexpression in AND)
-	if v, exist := cc.CostsMap["-"+nodeName]; exist {
-		return v
-	}
-
 	if v, exist := cc.CostsMap[nodeName]; exist {
 		return v
 	}

--- a/compile.go
+++ b/compile.go
@@ -16,6 +16,7 @@ const (
 	ConstantFolding Option = "constant_folding"
 
 	Debug                 Option = "debug"
+	ReportEvent           Option = "report_event"
 	InfixNotation         Option = "infix_notation"
 	AllowUnknownSelectors Option = "allow_unknown_selectors"
 )
@@ -63,6 +64,9 @@ var (
 	}
 	EnableDebug CompileOption = func(c *CompileConfig) {
 		c.CompileOptions[Debug] = true
+	}
+	EnableReportEvent CompileOption = func(c *CompileConfig) {
+		c.CompileOptions[ReportEvent] = true
 	}
 	Optimizations = func(enable bool, opts ...Option) CompileOption {
 		return func(c *CompileConfig) {
@@ -474,7 +478,8 @@ func buildExpr(cc *CompileConfig, ast *astNode, size int) *Expr {
 	calAndSetStackSize(e)
 	calAndSetShortCircuit(e)
 	calAndSetShortCircuitForRCO(e)
-	if cc.CompileOptions[Debug] {
+
+	if cc.CompileOptions[ReportEvent] || cc.CompileOptions[Debug] {
 		calAndSetEventNode(e)
 	}
 
@@ -774,5 +779,5 @@ func calAndSetEventNode(e *Expr) {
 
 	e.nodes = res
 	e.parentIdx = parents
-	e.EventChan = make(chan Event)
+	e.EventChan = make(chan Event, 64)
 }

--- a/compile.go
+++ b/compile.go
@@ -475,7 +475,7 @@ func buildExpr(cc *CompileConfig, ast *astNode, size int) *Expr {
 	calAndSetShortCircuit(e)
 	calAndSetShortCircuitForRCO(e)
 	if cc.CompileOptions[Debug] {
-		calAndSetDebugInfo(e)
+		calAndSetEventNode(e)
 	}
 
 	return e
@@ -694,7 +694,7 @@ func calAndSetShortCircuitForRCO(e *Expr) {
 	}
 }
 
-func calAndSetDebugInfo(e *Expr) {
+func calAndSetEventNode(e *Expr) {
 	var wrapDebugInfo = func(name Value, op Operator) Operator {
 		return func(ctx *Ctx, params []Value) (res Value, err error) {
 			res, err = op(ctx, params)
@@ -715,7 +715,7 @@ func calAndSetDebugInfo(e *Expr) {
 	for i := int16(0); i < size; i++ {
 		realNode := nodes[i]
 		debugNode := &node{
-			flag:     debug,
+			flag:     event,
 			childCnt: realNode.childCnt,
 			osTop:    realNode.osTop,
 			scIdx:    realNode.scIdx,
@@ -751,7 +751,7 @@ func calAndSetDebugInfo(e *Expr) {
 			continue
 		}
 
-		if n.getNodeType() == debug {
+		if n.getNodeType() == event {
 			parents[i] = debugIdxes[p]
 		} else {
 			parents[i] = realIdxes[p]

--- a/compile.go
+++ b/compile.go
@@ -128,31 +128,29 @@ func (cc *CompileConfig) getCosts(nodeType uint8, nodeName string) int {
 		defaultCost  = 5
 		selectorCost = 7
 		operatorCost = 10
+
+		selectorNode = "selector"
+		operatorNode = "operator"
 	)
 
-	fallback := defaultCost
-	var prefix string
+	if v, exist := cc.CostsMap[nodeName]; exist {
+		return v
+	}
+
 	switch nodeType {
 	case selector:
-		prefix = "selector"
-		fallback = selectorCost
-	case operator, fastOperator:
-		prefix = "operator"
-		fallback = operatorCost
-	}
-
-	keys := []string{
-		fmt.Sprintf("%s.%s", prefix, nodeName), // operator.abs
-		nodeName,                               // abs
-		fmt.Sprintf("%ss", prefix),             // operators
-	}
-
-	for _, key := range keys {
-		if v, exist := cc.CostsMap[key]; exist {
+		if v, exist := cc.CostsMap[selectorNode]; exist {
 			return v
 		}
+		return selectorCost
+	case operator, fastOperator:
+		if v, exist := cc.CostsMap[operatorNode]; exist {
+			return v
+		}
+		return operatorCost
+	default:
+		return defaultCost
 	}
-	return fallback
 }
 
 func Compile(originConf *CompileConfig, exprStr string) (*Expr, error) {

--- a/compile_test.go
+++ b/compile_test.go
@@ -62,8 +62,8 @@ func TestCopyCompileConfig(t *testing.T) {
 			},
 		},
 		CostsMap: map[string]int{
-			"selectors": 10,
-			"operators": 20,
+			"selector": 10,
+			"operator": 20,
 		},
 		CompileOptions: map[Option]bool{
 			Reordering:      true,
@@ -96,8 +96,8 @@ func TestGetCosts(t *testing.T) {
 			"not_null": func(_ *Ctx, _ []Value) (Value, error) { return false, nil },
 		},
 		CostsMap: map[string]int{
-			"selectors": 10, // generally costs for all selectors
-			"operators": 20, // generally costs for all operators
+			"selector": 10, // generally costs for all selectors
+			"operator": 20, // generally costs for all operators
 
 			"is_child": 13, // specified costs for operator `is_child`
 			"birthday": 11, // specified costs for selector `birthday`
@@ -716,9 +716,9 @@ func TestReordering(t *testing.T) {
 					"v6": SelectorKey(6),
 				},
 				CostsMap: map[string]int{
-					"selectors": 2,
-					"operators": 3,
-					"v3":        50,
+					"selector": 2,
+					"operator": 3,
+					"v3":       50,
 				},
 			},
 			ast: verifyNode{
@@ -845,9 +845,9 @@ func TestOptimize(t *testing.T) {
 					"v6": SelectorKey(6),
 				},
 				CostsMap: map[string]int{
-					"selectors": 2,
-					"operators": 3,
-					"v3":        50,
+					"selector": 2,
+					"operator": 3,
+					"v3":       50,
 				},
 			},
 			ast: verifyNode{

--- a/engine.go
+++ b/engine.go
@@ -380,7 +380,7 @@ func getSelectorValueProxy(ctx *Ctx, n *node) (Value, error) {
 
 func reportEvent(e *Expr, curtIdx int16, os []Value, osTop int16) {
 	stack := make([]Value, osTop+1)
-	for i := osTop; i >= 0; i-- {
+	for i := int16(0); i <= osTop; i++ {
 		stack[i] = os[i]
 	}
 

--- a/engine.go
+++ b/engine.go
@@ -51,10 +51,19 @@ func (n *node) getNodeType() uint8 {
 	return n.flag & nodeTypeMask
 }
 
+type EventType string
+
+const (
+	OpExecEvent EventType = "OP_EXEC"
+	LoopEvent   EventType = "LOOP"
+)
+
 type Event struct {
-	CurtIdx int16
-	Stack   []Value
-	Data    interface{}
+	CurtIdx   int16
+	EventType EventType
+	NodeValue interface{}
+	Stack     []Value
+	Data      interface{}
 }
 
 type Expr struct {
@@ -62,7 +71,7 @@ type Expr struct {
 	nodes        []*node
 	parentIdx    []int16
 
-	eventChan chan<- Event
+	EventChan chan Event
 }
 
 func Eval(expr string, vals map[string]interface{}, confs ...*CompileConfig) (Value, error) {
@@ -375,8 +384,10 @@ func reportEvent(e *Expr, curtIdx int16, os []Value, osTop int16) {
 		stack[i] = os[i]
 	}
 
-	e.eventChan <- Event{
-		CurtIdx: curtIdx,
-		Stack:   stack,
+	e.EventChan <- Event{
+		EventType: LoopEvent,
+		NodeValue: e.nodes[curtIdx].value,
+		CurtIdx:   curtIdx,
+		Stack:     stack,
 	}
 }

--- a/engine.go
+++ b/engine.go
@@ -79,6 +79,35 @@ func Eval(expr string, vals map[string]interface{}, confs ...*CompileConfig) (Va
 	return tree.Eval(NewCtxWithMap(conf, vals))
 }
 
+func (e *Expr) EvalBool(ctx *Ctx) (bool, error) {
+	res, err := e.Eval(ctx)
+	if err != nil {
+		return false, err
+	}
+	b, ok := res.(bool)
+	if !ok {
+		return false, errors.New("invalid result type error")
+	}
+	return b, nil
+}
+
+func (e *Expr) TryEvalBool(ctx *Ctx) (bool, error) {
+	res, err := e.Eval(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if res == DNE {
+		return false, ErrDNE
+	}
+
+	b, ok := res.(bool)
+	if !ok {
+		return false, errors.New("invalid result type error")
+	}
+	return b, nil
+}
+
 func (e *Expr) Eval(ctx *Ctx) (res Value, err error) {
 	var (
 		nodes = e.nodes

--- a/engine_test.go
+++ b/engine_test.go
@@ -1088,11 +1088,11 @@ func TestExpr_TryEval(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = true
+		printProgress = false
 	)
 
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -444,12 +444,14 @@ func TestExpr_Eval(t *testing.T) {
 			expr, err := Compile(cc, c.s)
 			assertNil(t, err)
 			if debugMode {
+				HandleDebugEvent(expr)
 				fmt.Println(Dump(expr))
 				fmt.Println()
 				fmt.Println(DumpTable(expr, true))
 			}
 
 			res, err := expr.Eval(ctx)
+
 			assertNil(t, err)
 
 			if debugMode {
@@ -466,6 +468,10 @@ func TestExpr_Eval(t *testing.T) {
 
 			if c.want != nil {
 				assertEquals(t, rcoRes, c.want)
+			}
+
+			if debugMode {
+				close(expr.EventChan)
 			}
 		})
 	}
@@ -1057,12 +1063,16 @@ func TestExpr_TryEval(t *testing.T) {
 			expr, err := Compile(cc, c.s)
 			assertNil(t, err)
 			if debugMode {
+				HandleDebugEvent(expr)
 				fmt.Println(Dump(expr))
 				fmt.Println()
 				fmt.Println(DumpTable(expr, true))
 			}
 
 			res, err := expr.TryEval(ctx)
+			if debugMode {
+				close(expr.EventChan)
+			}
 			assertNil(t, err)
 
 			if debugMode {

--- a/engine_test.go
+++ b/engine_test.go
@@ -446,7 +446,7 @@ func TestExpr_Eval(t *testing.T) {
 			if debugMode {
 				fmt.Println(Dump(expr))
 				fmt.Println()
-				fmt.Println(DumpTable(expr))
+				fmt.Println(DumpTable(expr, true))
 			}
 
 			res, err := expr.Eval(ctx)
@@ -1059,7 +1059,7 @@ func TestExpr_TryEval(t *testing.T) {
 			if debugMode {
 				fmt.Println(Dump(expr))
 				fmt.Println()
-				fmt.Println(DumpTable(expr))
+				fmt.Println(DumpTable(expr, true))
 			}
 
 			res, err := expr.TryEval(ctx)

--- a/engine_test.go
+++ b/engine_test.go
@@ -1078,11 +1078,11 @@ func TestExpr_TryEval(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 10000
+		size          = 3000000
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = false
+		printProgress = true
 	)
 
 	const (

--- a/selector.go
+++ b/selector.go
@@ -202,6 +202,12 @@ func unifyType(val Value) Value {
 			temp[i] = int64(iv)
 		}
 		return temp
+	case []int32:
+		temp := make([]int64, len(v))
+		for i, iv := range v {
+			temp[i] = int64(iv)
+		}
+		return temp
 	case int32:
 		return int64(v)
 	case int16:

--- a/selector.go
+++ b/selector.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -21,6 +22,8 @@ const UndefinedSelKey SelectorKey = math.MinInt16
 // When executing an expression with RCO, if the value of a SelectorKey is not cached,
 // the selector proxy will return DNE as its value
 var DNE = struct{ DoesNotExist string }{DoesNotExist: "DNE"}
+
+var ErrDNE = errors.New("DNE")
 
 // Selector is used to get values of the expression variables.
 // Note that there are two types of keys in each method parameters,

--- a/util.go
+++ b/util.go
@@ -398,7 +398,7 @@ func IndentByParentheses(s string) string {
 func Dump(e *Expr) string {
 	var getChildIdxes = func(idx int16) (res []int16) {
 		for i, p := range e.parentIdx {
-			if p == idx && e.nodes[i].getNodeType() != debug {
+			if p == idx && e.nodes[i].getNodeType() != event {
 				res = append(res, int16(i))
 			}
 		}
@@ -454,8 +454,8 @@ func Dump(e *Expr) string {
 
 func dumpLeafNode(node *node) (string, bool) {
 	switch node.getNodeType() {
-	case debug:
-		return "debug", false
+	case event:
+		return "eventNode", false
 	case selector:
 		return fmt.Sprint(node.value), true
 	case operator, fastOperator:
@@ -519,10 +519,7 @@ func contains(params []Value, target Value) bool {
 	return false
 }
 
-func DumpTable(expr *Expr, skipDebug ...bool) string {
-	if len(skipDebug) == 0 {
-		skipDebug = []bool{true}
-	}
+func DumpTable(expr *Expr, skipEventNode bool) string {
 
 	type fetcher struct {
 		name string
@@ -555,8 +552,8 @@ func DumpTable(expr *Expr, skipDebug ...bool) string {
 			res = "C"
 		case cond:
 			res = "COND"
-		case debug:
-			res = "D"
+		case event:
+			res = "EVNT"
 		}
 
 		if f&scIfTrue == scIfTrue {
@@ -633,7 +630,7 @@ func DumpTable(expr *Expr, skipDebug ...bool) string {
 	for f, n := range fetchers {
 		sb.WriteString(fmt.Sprintf("%5s: ", n.name))
 		for j := 0; j < size; j++ {
-			if expr.nodes[j].flag&nodeTypeMask == debug && skipDebug[0] {
+			if expr.nodes[j].flag&nodeTypeMask == event && skipEventNode {
 				continue
 			}
 


### PR DESCRIPTION
## Summary
This PR updates engine and compile to enable firing events during executing expression

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/onheap/eval	1.781s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16       	51518523	        62.58 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16        	53547080	        64.25 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16      	54988282	        63.59 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16       	51509942	        64.93 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocalRCO-16    	28407207	       122.1 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/local	17.822s

```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     37346|     30000|      4930|        16|    2.141s|
|       2 %|       2 %|     62632|     60000|        93|       139|    3.641s|
|       3 %|       3 %|     92851|     90000|       363|        88|    3.781s|
|       4 %|       4 %|    122850|    120000|       301|       149|    4.217s|
|       5 %|       5 %|    154239|    150000|      1601|       238|    3.813s|
|       6 %|       6 %|    188667|    180000|      6213|        54|    3.946s|
|       7 %|       7 %|    214994|    210000|      2524|        70|    3.921s|
|       8 %|       8 %|    242398|    240000|         0|         0|    3.801s|
|       9 %|       9 %|    272821|    270000|       339|        82|    4.126s|
|      10 %|      10 %|    302469|    300000|        30|        39|    3.942s|
|      11 %|      11 %|    332781|    330000|       292|        89|     4.21s|
|      12 %|      12 %|    362858|    360000|       408|        50|    4.139s|
|      13 %|      13 %|    392407|    390000|         0|        10|    4.306s|
|      14 %|      14 %|    423145|    420000|       629|       116|     5.28s|
|      15 %|      15 %|    452509|    450000|        17|        92|    4.699s|
|      16 %|      16 %|    482753|    480000|       208|       145|    4.012s|
|      17 %|      17 %|    512725|    510000|       323|         2|    4.034s|
|      18 %|      18 %|    542499|    540000|        92|         7|    4.043s|
|      19 %|      19 %|    572794|    570000|       132|       262|    4.649s|
|      20 %|      20 %|    602685|    600000|       168|       117|    4.387s|
|      21 %|      21 %|    632478|    630000|        30|        48|    4.299s|
|      22 %|      22 %|    662530|    660000|        86|        44|    4.192s|
|      23 %|      23 %|    692632|    690000|       166|        66|    5.401s|
|      24 %|      24 %|    722495|    720000|        80|        15|     4.54s|
|      25 %|      25 %|    752490|    750000|        81|         9|    4.525s|
|      26 %|      26 %|    782422|    780000|        11|        11|    4.128s|
|      27 %|      27 %|    813261|    810000|       829|        32|    3.998s|
|      28 %|      28 %|    842691|    840000|       210|        81|    4.038s|
|      29 %|      29 %|    874552|    870000|      2108|        44|    4.204s|
|      30 %|      30 %|    902430|    900000|         8|        22|    4.372s|
|      31 %|      31 %|    932673|    930000|       149|       124|    4.119s|
|      32 %|      32 %|    962584|    960000|        81|       103|    4.017s|
|      33 %|      33 %|    993249|    990000|       827|        22|    4.176s|
|      34 %|      34 %|   1022527|   1020000|        89|        38|    4.029s|
|      35 %|      35 %|   1052518|   1050000|         0|       120|    4.204s|
|      36 %|      36 %|   1083046|   1080000|       641|         5|    4.232s|
|      37 %|      37 %|   1112760|   1110000|       243|       117|    4.634s|
|      38 %|      38 %|   1142389|   1140000|         0|         0|    4.966s|
|      39 %|      39 %|   1174941|   1170000|      2303|       238|    4.577s|
|      40 %|      40 %|   1202503|   1200000|        91|        12|    5.008s|
|      41 %|      41 %|   1234159|   1230000|      1706|        53|    4.521s|
|      42 %|      42 %|   1264187|   1260000|      1632|       155|    4.305s|
|      43 %|      43 %|   1292507|   1290000|        26|        81|    4.283s|
|      44 %|      44 %|   1322468|   1320000|        67|         1|    4.526s|
|      45 %|      45 %|   1352559|   1350000|        57|       102|    4.356s|
|      46 %|      46 %|   1382647|   1380000|         0|       249|    4.334s|
|      47 %|      47 %|   1412588|   1410000|       124|        64|    4.201s|
|      48 %|      48 %|   1442499|   1440000|        26|        73|    4.273s|
|      49 %|      49 %|   1472390|   1470000|         0|         0|    4.213s|
|      50 %|      50 %|   1502433|   1500000|         0|        35|    4.431s|
|      51 %|      51 %|   1532388|   1530000|         0|         1|    4.388s|
|      52 %|      52 %|   1562751|   1560000|       172|       179|     4.43s|
|      53 %|      53 %|   1592337|   1590000|         0|         0|    4.475s|
|      54 %|      54 %|   1622631|   1620000|       180|        51|    4.389s|
|      55 %|      55 %|   1652565|   1650000|       161|         4|    4.236s|
|      56 %|      56 %|   1682416|   1680000|        16|         0|    4.327s|
|      57 %|      57 %|   1712680|   1710000|       277|         3|     4.39s|
|      58 %|      58 %|   1742703|   1740000|       233|        70|    4.253s|
|      59 %|      59 %|   1772530|   1770000|       118|        12|     4.22s|
|      60 %|      60 %|   1802459|   1800000|        56|         3|    4.166s|
|      61 %|      61 %|   1832411|   1830000|         0|        13|    4.158s|
|      62 %|      62 %|   1862781|   1860000|       151|       230|     4.24s|
|      63 %|      63 %|   1892666|   1890000|       230|        36|    4.267s|
|      64 %|      64 %|   1923084|   1920000|        97|       587|    4.417s|
|      65 %|      65 %|   1952665|   1950000|       171|        94|    4.279s|
|      66 %|      66 %|   1983095|   1980000|       162|       533|    4.382s|
|      67 %|      67 %|   2012557|   2010000|       129|        28|    4.307s|
|      68 %|      68 %|   2043604|   2040000|      1202|         2|    4.661s|
|      69 %|      69 %|   2073968|   2070000|      1169|       399|    4.404s|
|      70 %|      70 %|   2102494|   2100000|        91|         3|    4.386s|
|      71 %|      71 %|   2132446|   2130000|        26|        20|    4.401s|
|      72 %|      72 %|   2162389|   2160000|         0|         0|    4.399s|
|      73 %|      73 %|   2192661|   2190000|       116|       145|    4.379s|
|      74 %|      74 %|   2222441|   2220000|        20|        21|    4.719s|
|      75 %|      75 %|   2252708|   2250000|       183|       126|    4.225s|
|      76 %|      76 %|   2282596|   2280000|        83|       113|    4.359s|
|      77 %|      77 %|   2312757|   2310000|       327|        30|    4.394s|
|      78 %|      78 %|   2342588|   2340000|       159|        29|     4.43s|
|      79 %|      79 %|   2372385|   2370000|         0|         0|    4.397s|
|      80 %|      80 %|   2408044|   2400000|      5629|        15|    2.754s|
|      81 %|      81 %|   2434899|   2430000|      2262|       237|     4.46s|
|      82 %|      82 %|   2465065|   2460000|      2495|       170|    4.541s|
|      83 %|      83 %|   2492375|   2490000|         0|         0|    4.281s|
|      84 %|      84 %|   2522461|   2520000|        37|        24|    5.718s|
|      85 %|      85 %|   2552518|   2550000|        93|        25|    5.025s|
|      86 %|      86 %|   2582418|   2580000|        17|         1|    4.606s|
|      87 %|      87 %|   2613205|   2610000|       737|        68|    4.304s|
|      88 %|      88 %|   2642404|   2640000|         0|         9|    4.365s|
|      89 %|      89 %|   2672455|   2670000|        47|         8|     4.36s|
|      90 %|      90 %|   2702498|   2700000|        90|         8|    4.291s|
|      91 %|      91 %|   2732768|   2730000|       354|        14|    4.384s|
|      92 %|      92 %|   2762831|   2760000|       291|       140|    4.533s|
|      93 %|      93 %|   2792409|   2790000|         4|         5|    4.389s|
|      94 %|      94 %|   2824560|   2820000|      2056|       104|    4.559s|
|      95 %|      95 %|   2852561|   2850000|       156|         5|    4.471s|
|      96 %|      96 %|   2882452|   2880000|         0|        55|     4.47s|
|      97 %|      97 %|   2912549|   2910000|       149|         0|    4.425s|
|      98 %|      98 %|   2942801|   2940000|       401|         0|    4.388s|
|      99 %|      99 %|   2972705|   2970000|       101|       204|    4.257s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|     4.49s|
PASS
ok  	github.com/onheap/eval	436.197s

```

## Reviewers
@onheap