### PR TITLE
[event] [compiler] update event

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -692,6 +692,35 @@ func calAndSetShortCircuitForRCO(e *Expr) {
 	}
 }
 
+type NodeType uint8
+
+const (
+	ConstantNode     = NodeType(constant)
+	SelectorNode     = NodeType(selector)
+	OperatorNode     = NodeType(operator)
+	FastOperatorNode = NodeType(fastOperator)
+	CondNode         = NodeType(cond)
+	EventNode        = NodeType(event)
+)
+
+func (t NodeType) String() string {
+	switch t {
+	case ConstantNode:
+		return "constant"
+	case SelectorNode:
+		return "selector"
+	case OperatorNode:
+		return "operator"
+	case FastOperatorNode:
+		return "fast_operator"
+	case CondNode:
+		return "cond"
+	case EventNode:
+		return "event"
+	}
+	return "unknown"
+}
+
 type OpEventData struct {
 	OpName string
 	Params []Value
@@ -699,18 +728,22 @@ type OpEventData struct {
 	Err    error
 }
 
+type LoopEventData struct {
+	CurtIdx   int16
+	NodeType  NodeType
+	NodeValue Value
+}
+
 func calAndSetEventNode(e *Expr) {
 	var wrapOpEvent = func(n *node, eventType EventType) Operator {
 		var (
-			op       = n.operator
-			name     = n.value.(string)
-			nodeType = NodeType(n.flag & nodeTypeMask)
+			op   = n.operator
+			name = n.value.(string)
 		)
 		return func(ctx *Ctx, params []Value) (res Value, err error) {
 			res, err = op(ctx, params)
 			e.EventChan <- Event{
 				EventType: eventType,
-				NodeType:  nodeType,
 				Data: OpEventData{
 					OpName: name,
 					Params: params,
@@ -739,7 +772,11 @@ func calAndSetEventNode(e *Expr) {
 			osTop:    realNode.osTop,
 			scIdx:    realNode.scIdx,
 			selKey:   realNode.selKey,
-			value:    realNode.value,
+			value: LoopEventData{
+				CurtIdx:   int16(len(res) + 1), // the real node index
+				NodeType:  NodeType(realNode.flag & nodeTypeMask),
+				NodeValue: realNode.value,
+			},
 		}
 		res = append(res, debugNode)
 		eventNodeIdxes[i] = int16(len(res) - 1)
@@ -752,7 +789,7 @@ func calAndSetEventNode(e *Expr) {
 		case operator:
 			realNode.operator = wrapOpEvent(realNode, OpExecEvent)
 		case fastOperator:
-			realNode.operator = wrapOpEvent(realNode, FastOpExecEvent)
+			realNode.operator = wrapOpEvent(realNode, OpExecEvent)
 			// append child nodes of fast operator
 			res = append(res, nodes[i+1], nodes[i+2])
 			parents = append(parents, e.parentIdx[i+1], e.parentIdx[i+2])

--- a/engine_test.go
+++ b/engine_test.go
@@ -32,7 +32,7 @@ func TestExpr_Eval(t *testing.T) {
 	}{
 		{
 			want:          true,
-			optimizeLevel: disable,
+			optimizeLevel: onlyFast,
 			s: `
 (not
   (and
@@ -1130,7 +1130,7 @@ func TestRandomExpressions(t *testing.T) {
 		level         = 53
 		step          = size / 100
 		showSample    = false
-		printProgress = true
+		printProgress = false
 	)
 
 	const (

--- a/engine_test.go
+++ b/engine_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestExpr_Eval(t *testing.T) {
-	const debugMode bool = true
+	const debugMode bool = false
 
 	type optimizeLevel int
 	const (
@@ -1126,7 +1126,7 @@ func TestExpr_TryEval(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 30000
 		level         = 53
 		step          = size / 100
 		showSample    = false
@@ -1350,35 +1350,43 @@ func TestReportEvent(t *testing.T) {
 	assertEquals(t, events, []Event{
 		{
 			EventType: LoopEvent,
-			NodeType:  ConstantNode,
-			CurtIdx:   1,
-			Data:      int64(1),
 			Stack:     []Value{},
+			Data: LoopEventData{
+				NodeValue: int64(1),
+				NodeType:  ConstantNode,
+				CurtIdx:   1,
+			},
 		},
 		{
 			EventType: LoopEvent,
-			NodeType:  SelectorNode,
-			CurtIdx:   3,
-			Data:      "v2",
 			Stack:     []Value{int64(1)},
+			Data: LoopEventData{
+				NodeValue: "v2",
+				NodeType:  SelectorNode,
+				CurtIdx:   3,
+			},
 		},
 		{
 			EventType: LoopEvent,
-			NodeType:  SelectorNode,
-			CurtIdx:   5,
-			Data:      "v3",
 			Stack:     []Value{int64(1), int64(2)},
+			Data: LoopEventData{
+				NodeValue: "v3",
+				NodeType:  SelectorNode,
+				CurtIdx:   5,
+			},
 		},
 		{
 			EventType: LoopEvent,
-			NodeType:  OperatorNode,
-			CurtIdx:   7,
-			Data:      "+",
 			Stack:     []Value{int64(1), int64(2), int64(3)},
+			Data: LoopEventData{
+				NodeValue: "+",
+
+				NodeType: OperatorNode,
+				CurtIdx:  7,
+			},
 		},
 		{
 			EventType: OpExecEvent,
-			NodeType:  OperatorNode,
 			Data: OpEventData{
 				OpName: "+",
 				Params: []Value{int64(1), int64(2), int64(3)},

--- a/engine_test.go
+++ b/engine_test.go
@@ -1380,18 +1380,18 @@ func TestReportEvent(t *testing.T) {
 			Stack:     []Value{int64(1), int64(2), int64(3)},
 			Data: LoopEventData{
 				NodeValue: "+",
-
-				NodeType: OperatorNode,
-				CurtIdx:  7,
+				NodeType:  OperatorNode,
+				CurtIdx:   7,
 			},
 		},
 		{
 			EventType: OpExecEvent,
 			Data: OpEventData{
-				OpName: "+",
-				Params: []Value{int64(1), int64(2), int64(3)},
-				Res:    int64(6),
-				Err:    nil,
+				IsFastOp: false,
+				OpName:   "+",
+				Params:   []Value{int64(1), int64(2), int64(3)},
+				Res:      int64(6),
+				Err:      nil,
 			},
 		},
 	})

--- a/selector.go
+++ b/selector.go
@@ -21,7 +21,11 @@ const UndefinedSelKey SelectorKey = math.MinInt16
 // DNE means Does Not Exist, it used in RCO (remote call optimization).
 // When executing an expression with RCO, if the value of a SelectorKey is not cached,
 // the selector proxy will return DNE as its value
-var DNE = struct{ DoesNotExist string }{DoesNotExist: "DNE"}
+type dne struct{ DoesNotExist string }
+
+func (dne) String() string { return "DNE" }
+
+var DNE = dne{DoesNotExist: "DNE"}
 
 var ErrDNE = errors.New("DNE")
 

--- a/util.go
+++ b/util.go
@@ -679,8 +679,8 @@ func HandleDebugEvent(e *Expr) {
 			case OpExecEvent:
 				data := ev.Data.(OpEventData)
 				fmt.Printf(
-					"%13s: op: %s, params: %v, res: %v, err: %v\n",
-					"Exec Operator", data.OpName, data.Params, data.Res, data.Err)
+					"%13s: op: %s, isFast: %v, params: %v, res: %v, err: %v\n",
+					"Exec Operator", data.OpName, data.IsFastOp, data.Params, data.Res, data.Err)
 			case LoopEvent:
 				var (
 					sb   strings.Builder
@@ -693,7 +693,7 @@ func HandleDebugEvent(e *Expr) {
 				}
 
 				if curt.CurtIdx-prev.CurtIdx > minSteps {
-					sb.WriteString(fmt.Sprintf("%13s: [%v] jump to [%v]\n\n", "Short Circuit", prev.NodeValue, curt))
+					sb.WriteString(fmt.Sprintf("%13s: [%v] jump to [%v]\n\n", "Short Circuit", prev.NodeValue, curt.NodeValue))
 				} else {
 					sb.WriteString(fmt.Sprintf("\n"))
 				}

--- a/util.go
+++ b/util.go
@@ -698,7 +698,7 @@ func HandleDebugEvent(e *Expr) {
 					sb.WriteString(fmt.Sprintf("\n"))
 				}
 
-				sb.WriteString(fmt.Sprintf("%13s: [%v], type:[%s], idx:[%d]\n", "Current Node", curt.NodeValue, "ddd", curt.CurtIdx))
+				sb.WriteString(fmt.Sprintf("%13s: [%v], type:[%s], idx:[%d]\n", "Current Node", curt.NodeValue, curt.NodeType.String(), curt.CurtIdx))
 
 				sb.WriteString(fmt.Sprintf("%13s: ", "Operand Stack"))
 				for i := len(ev.Stack) - 1; i >= 0; i-- {

--- a/util.go
+++ b/util.go
@@ -521,6 +521,11 @@ func contains(params []Value, target Value) bool {
 
 func DumpTable(expr *Expr, skipEventNode bool) string {
 
+	var (
+		width  = 5
+		format = fmt.Sprintf("|%%%dv", width)
+	)
+
 	type fetcher struct {
 		name string
 		fn   func(e *Expr, i int) Value
@@ -582,11 +587,10 @@ func DumpTable(expr *Expr, skipEventNode bool) string {
 					v = n.value
 				}
 				res := fmt.Sprintf("%v", v)
-				l := len(res)
-				if l > 4 {
-					l = 4
+				if l := len(res); l > width {
+					res = res[:width]
 				}
-				return res[0:l]
+				return res
 			},
 		},
 		pIdx: {
@@ -640,7 +644,7 @@ func DumpTable(expr *Expr, skipEventNode bool) string {
 				continue
 			}
 
-			sb.WriteString(fmt.Sprintf("|%4v", fetchers[f].fn(expr, j)))
+			sb.WriteString(fmt.Sprintf(format, fetchers[f].fn(expr, j)))
 		}
 		sb.WriteString("|\n")
 	}

--- a/util.go
+++ b/util.go
@@ -575,7 +575,13 @@ func DumpTable(expr *Expr, skipEventNode bool) string {
 		node: {
 			name: "node",
 			fn: func(e *Expr, i int) Value {
-				res := fmt.Sprintf("%v", e.nodes[i].value)
+				var v Value
+				if n := e.nodes[i]; n.getNodeType() == event {
+					v = n.value.(LoopEventData).NodeValue
+				} else {
+					v = n.value
+				}
+				res := fmt.Sprintf("%v", v)
 				l := len(res)
 				if l > 4 {
 					l = 4
@@ -663,7 +669,7 @@ func GetSelectorKeys(e *Expr) []SelectorKeys {
 
 func HandleDebugEvent(e *Expr) {
 	go func() {
-		var prev Event
+		var prev LoopEventData
 		for ev := range e.EventChan {
 			switch ev.EventType {
 			case OpExecEvent:
@@ -671,24 +677,24 @@ func HandleDebugEvent(e *Expr) {
 				fmt.Printf(
 					"%13s: op: %s, params: %v, res: %v, err: %v\n",
 					"Exec Operator", data.OpName, data.Params, data.Res, data.Err)
-			case FastOpExecEvent:
-				data := ev.Data.(OpEventData)
-				fmt.Printf(
-					"%13s: op: %s, params: %v, res: %v, err: %v\n",
-					"Exec Fast Operator", data.OpName, data.Params, data.Res, data.Err)
 			case LoopEvent:
 				var (
 					sb   strings.Builder
-					curt = ev.Data
+					curt = ev.Data.(LoopEventData)
 				)
 
-				if ev.CurtIdx-prev.CurtIdx > 2 {
-					sb.WriteString(fmt.Sprintf("%13s: [%v] jump to [%v]\n\n", "Short Circuit", prev.Data, curt))
+				var minSteps int16 = 2
+				if prev.NodeType == FastOperatorNode {
+					minSteps = 4
+				}
+
+				if curt.CurtIdx-prev.CurtIdx > minSteps {
+					sb.WriteString(fmt.Sprintf("%13s: [%v] jump to [%v]\n\n", "Short Circuit", prev.NodeValue, curt))
 				} else {
 					sb.WriteString(fmt.Sprintf("\n"))
 				}
 
-				sb.WriteString(fmt.Sprintf("%13s: [%v], type:[%s], idx:[%d]\n", "Current Node", curt, ev.NodeType.String(), ev.CurtIdx))
+				sb.WriteString(fmt.Sprintf("%13s: [%v], type:[%s], idx:[%d]\n", "Current Node", curt.NodeValue, "ddd", curt.CurtIdx))
 
 				sb.WriteString(fmt.Sprintf("%13s: ", "Operand Stack"))
 				for i := len(ev.Stack) - 1; i >= 0; i-- {
@@ -697,7 +703,7 @@ func HandleDebugEvent(e *Expr) {
 				sb.WriteString("|")
 				fmt.Println(sb.String())
 
-				prev = ev
+				prev = curt
 			default:
 				fmt.Printf("Unknown event: %+v\n", ev)
 			}

--- a/util.go
+++ b/util.go
@@ -588,7 +588,7 @@ func DumpTable(expr *Expr, skipEventNode bool) string {
 				}
 				res := fmt.Sprintf("%v", v)
 				if l := len(res); l > width {
-					res = res[:width]
+					res = res[:width-1] + "…"
 				}
 				return res
 			},


### PR DESCRIPTION
## Summary
This PR update event node to reduce the costs of executing `reportEvent()`.

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/onheap/eval	4.326s
```

- [ ] No degradation in performance (a litter bit of degradation, but don't know why, I will find out it later)
```
❯ go test -bench=BenchmarkEval -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	48186832	        64.00 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	55479325	        62.09 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	54903906	        64.13 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	57486080	        61.35 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal2-16    	54831735	        63.43 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain2-16     	54873313	        61.63 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal3-16    	52796114	        63.89 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain3-16     	55887967	        61.27 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal4-16    	55106013	        63.61 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain4-16     	54958110	        61.94 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal5-16    	53800062	        63.92 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain5-16     	56818304	        61.13 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal6-16    	52956039	        64.10 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain6-16     	50822040	        62.15 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal7-16    	53332407	        64.42 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain7-16     	56472696	        62.48 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal8-16    	52830906	        64.68 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain8-16     	50343921	        63.22 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal9-16    	52926835	        64.75 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain9-16     	56881431	        61.47 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/local	70.170s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     51772|     40000|      9193|       179|    3.871s|
|       2 %|       2 %|     86686|     80000|      4277|         9|     5.02s|
|       3 %|       3 %|    126965|    120000|      4559|         6|    5.452s|
|       4 %|       4 %|    162805|    160000|       247|       158|    5.642s|
|       5 %|       5 %|    208020|    200000|      5393|       227|    5.735s|
|       6 %|       6 %|    242788|    240000|       257|       131|    6.128s|
|       7 %|       7 %|    282433|    280000|         0|        46|    5.677s|
|       8 %|       8 %|    322485|    320000|         0|        89|    5.313s|
|       9 %|       9 %|    363895|    360000|      1373|       122|     5.66s|
|      10 %|      10 %|    402826|    400000|       245|       181|    6.056s|
|      11 %|      11 %|    444181|    440000|      1276|       505|    6.187s|
|      12 %|      12 %|    484877|    480000|      1821|       656|    5.637s|
|      13 %|      13 %|    522566|    520000|         0|       171|    5.682s|
|      14 %|      14 %|    562689|    560000|       163|       126|    6.261s|
|      15 %|      15 %|    602872|    600000|       300|       172|     5.45s|
|      16 %|      16 %|    642398|    640000|         0|         0|    5.392s|
|      17 %|      17 %|    684247|    680000|       920|       927|    5.611s|
|      18 %|      18 %|    722758|    720000|       358|         0|    5.247s|
|      19 %|      19 %|    762683|    760000|       192|        91|    5.437s|
|      20 %|      20 %|    805440|    800000|      2993|        47|    5.439s|
|      21 %|      21 %|    842588|    840000|        50|       138|    5.346s|
|      22 %|      22 %|    882501|    880000|         0|       107|    5.273s|
|      23 %|      23 %|    924315|    920000|      1854|        61|    5.375s|
|      24 %|      24 %|    962488|    960000|        64|        24|    5.241s|
|      25 %|      25 %|   1003164|   1000000|         0|       770|    5.425s|
|      26 %|      26 %|   1042394|   1040000|         0|         0|    5.509s|
|      27 %|      27 %|   1082461|   1080000|         0|        67|     5.61s|
|      28 %|      28 %|   1123376|   1120000|       952|        24|    5.615s|
|      29 %|      29 %|   1164561|   1160000|      2013|       148|    5.855s|
|      30 %|      30 %|   1203352|   1200000|       855|        97|    5.848s|
|      31 %|      31 %|   1245537|   1240000|      2820|       317|    5.752s|
|      32 %|      32 %|   1282888|   1280000|       486|         2|    5.712s|
|      33 %|      33 %|   1324343|   1320000|      1791|       152|    5.724s|
|      34 %|      34 %|   1363487|   1360000|      1072|        15|     5.61s|
|      35 %|      35 %|   1403038|   1400000|       628|        10|    5.353s|
|      36 %|      36 %|   1443766|   1440000|      1176|       190|    5.629s|
|      37 %|      37 %|   1482671|   1480000|        19|       252|    5.713s|
|      38 %|      38 %|   1522525|   1520000|         0|       154|    5.799s|
|      39 %|      39 %|   1563234|   1560000|       598|       236|    5.612s|
|      40 %|      40 %|   1602441|   1600000|         0|        41|    5.674s|
|      41 %|      41 %|   1643116|   1640000|       548|       168|     5.67s|
|      42 %|      42 %|   1682413|   1680000|         9|         4|     5.64s|
|      43 %|      43 %|   1723500|   1720000|       975|       125|     6.14s|
|      44 %|      44 %|   1763455|   1760000|       958|        97|    5.992s|
|      45 %|      45 %|   1802580|   1800000|       162|        18|     6.05s|
|      46 %|      46 %|   1842868|   1840000|       394|        74|    6.046s|
|      47 %|      47 %|   1883635|   1880000|      1235|         0|    5.894s|
|      48 %|      48 %|   1923101|   1920000|       542|       159|    6.046s|
|      49 %|      49 %|   1962512|   1960000|        74|        38|    6.093s|
|      50 %|      50 %|   2003122|   2000000|       702|        20|    6.041s|
|      51 %|      51 %|   2042551|   2040000|        52|        99|    5.794s|
|      52 %|      52 %|   2082455|   2080000|         0|        63|    5.663s|
|      53 %|      53 %|   2122426|   2120000|        20|         6|    5.782s|
|      54 %|      54 %|   2162588|   2160000|       188|         0|    5.711s|
|      55 %|      55 %|   2203364|   2200000|       959|         5|    5.846s|
|      56 %|      56 %|   2242583|   2240000|        75|       108|    5.742s|
|      57 %|      57 %|   2282595|   2280000|       184|        11|    5.752s|
|      58 %|      58 %|   2322676|   2320000|        67|       209|    5.848s|
|      59 %|      59 %|   2362950|   2360000|       550|         0|    5.932s|
|      60 %|      60 %|   2402483|   2400000|        50|        33|    5.833s|
|      61 %|      61 %|   2445259|   2440000|      2746|       113|    5.844s|
|      62 %|      62 %|   2482412|   2480000|         6|         6|     5.65s|
|      63 %|      63 %|   2522469|   2520000|        49|        20|    5.561s|
|      64 %|      64 %|   2564570|   2560000|      2019|       151|    5.723s|
|      65 %|      65 %|   2602761|   2600000|       343|        18|    5.676s|
|      66 %|      66 %|   2642486|   2640000|        73|        13|    5.773s|
|      67 %|      67 %|   2682857|   2680000|       247|       210|    5.694s|
|      68 %|      68 %|   2722965|   2720000|       562|         3|    5.769s|
|      69 %|      69 %|   2762985|   2760000|       581|         4|    5.748s|
|      70 %|      70 %|   2803200|   2800000|       102|       698|    5.875s|
|      71 %|      71 %|   2842959|   2840000|       425|       134|    5.714s|
|      72 %|      72 %|   2883191|   2880000|       654|       137|    5.712s|
|      73 %|      73 %|   2922518|   2920000|        69|        49|    5.748s|
|      74 %|      74 %|   2962575|   2960000|       141|        34|      5.8s|
|      75 %|      75 %|   3002382|   3000000|         0|         0|    5.902s|
|      76 %|      76 %|   3043500|   3040000|      1099|         1|    6.068s|
|      77 %|      77 %|   3083571|   3080000|       300|       871|    6.211s|
|      78 %|      78 %|   3123018|   3120000|       105|       513|    5.935s|
|      79 %|      79 %|   3163056|   3160000|       189|       467|     5.73s|
|      80 %|      80 %|   3204165|   3200000|      1562|       203|    5.818s|
|      81 %|      81 %|   3242400|   3240000|         0|         7|    5.754s|
|      82 %|      82 %|   3282383|   3280000|         0|         0|    6.062s|
|      83 %|      83 %|   3322564|   3320000|       128|        36|    5.885s|
|      84 %|      84 %|   3365093|   3360000|      2645|        48|    5.869s|
|      85 %|      85 %|   3402333|   3400000|         0|        13|     5.69s|
|      86 %|      86 %|   3443673|   3440000|      1226|        47|    5.725s|
|      87 %|      87 %|   3482730|   3480000|       191|       139|    6.066s|
|      88 %|      88 %|   3522985|   3520000|       345|       240|    6.089s|
|      89 %|      89 %|   3562583|   3560000|       145|        38|    6.049s|
|      90 %|      90 %|   3602772|   3600000|       340|        32|    6.261s|
|      91 %|      91 %|   3644788|   3640000|      2366|        22|    5.999s|
|      92 %|      92 %|   3682488|   3680000|        77|        11|    5.684s|
|      93 %|      93 %|   3722463|   3720000|        62|         1|    5.734s|
|      94 %|      94 %|   3762469|   3760000|         0|        72|    5.585s|
|      95 %|      95 %|   3802620|   3800000|       199|        21|    5.883s|
|      96 %|      96 %|   3844504|   3840000|      2103|         1|    5.717s|
|      97 %|      97 %|   3885154|   3880000|      2747|         7|    5.879s|
|      98 %|      98 %|   3922462|   3920000|         0|        69|    6.165s|
|      99 %|      99 %|   3964240|   3960000|      1101|       739|    6.261s|
|     100 %|     100 %|   4000000|   4000000|         0|         0|    6.127s|
PASS
ok  	github.com/onheap/eval	576.592s
```

## Reviewers
@onheap