### PR TITLE
[selector] minor refactor

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -92,7 +92,7 @@ func (e *Expr) EvalBool(ctx *Ctx) (bool, error) {
 }
 
 func (e *Expr) TryEvalBool(ctx *Ctx) (bool, error) {
-	res, err := e.Eval(ctx)
+	res, err := e.TryEval(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/operator.go
+++ b/operator.go
@@ -295,12 +295,12 @@ func (c comparison) execute(_ *Ctx, params []Value) (Value, error) {
 }
 
 func comparisonEquals(_ *Ctx, params []Value) (Value, error) {
-	if len(params) < 2 {
-		return nil, errCnt2(equals, params)
-	}
-
 	if len(params) == 2 {
 		return params[0] == params[1], nil
+	}
+
+	if len(params) < 2 {
+		return nil, errCnt2(equals, params)
 	}
 
 	v := params[0]

--- a/selector.go
+++ b/selector.go
@@ -78,9 +78,13 @@ func NewCtxWithMap(cc *CompileConfig, vals map[string]interface{}) *Ctx {
 		return &Ctx{Selector: NewMapSelector(vals)}
 	}
 
+	for key := range vals {
+		GetOrRegisterKey(cc, key)
+	}
+
 	var sel Selector
 	minKey, maxKey := selKeyRange(cc)
-	if 0 <= minKey && maxKey < 256 {
+	if minKey <= maxKey && 0 <= minKey && maxKey < 256 {
 		sel = NewSliceSelector(cc, vals)
 	} else {
 		sel = NewMapSelector(vals)

--- a/selector.go
+++ b/selector.go
@@ -74,102 +74,80 @@ func ToValueMap(m map[string]interface{}) map[string]Value {
 }
 
 func NewCtxWithMap(cc *CompileConfig, vals map[string]interface{}) *Ctx {
+	if cc.CompileOptions[AllowUnknownSelectors] {
+		return &Ctx{Selector: NewMapSelector(vals)}
+	}
+
 	var sel Selector
-	if sliceSelectorAvailable(cc) {
+	minKey, maxKey := selKeyRange(cc)
+	if 0 <= minKey && maxKey < 256 {
 		sel = NewSliceSelector(cc, vals)
 	} else {
 		sel = NewMapSelector(vals)
 	}
 
-	return &Ctx{
-		Selector: sel,
-	}
+	return &Ctx{Selector: sel}
 }
 
-func sliceSelectorAvailable(cc *CompileConfig) bool {
-	const (
-		minKeyRange = 0
-		maxKeyRange = 256
-	)
-
-	if cc.CompileOptions[AllowUnknownSelectors] {
-		return false
-	}
-
-	if len(cc.SelectorMap) > maxKeyRange-minKeyRange {
-		return false
-	}
-
+func selKeyRange(cc *CompileConfig) (min, max SelectorKey) {
+	min, max = math.MaxInt16, math.MinInt16
 	for _, key := range cc.SelectorMap {
-		if key < minKeyRange || key >= maxKeyRange {
-			return false
+		if key < min {
+			min = key
+		}
+		if key > max {
+			max = key
 		}
 	}
-
-	return true
+	return
 }
 
-type SliceSelector struct {
-	Values []Value
-}
+type SliceSelector []Value
 
 func NewSliceSelector(cc *CompileConfig, vals map[string]interface{}) SliceSelector {
-	maxKey := 0
-	for name := range vals {
-		key := GetOrRegisterKey(cc, name)
-		if int(key) > maxKey {
-			maxKey = int(key)
-		}
-	}
-	size := max(len(cc.SelectorMap), maxKey+1)
-	sel := SliceSelector{
-		Values: make([]Value, size),
-	}
+	_, maxKey := selKeyRange(cc)
+	sel := make([]Value, maxKey+1)
 	for name, val := range vals {
 		key := cc.SelectorMap[name]
-		sel.Values[key] = unifyType(val)
+		sel[key] = unifyType(val)
 	}
 	return sel
 }
 
 func (s SliceSelector) Get(key SelectorKey, _ string) (Value, error) {
-	if int(key) >= len(s.Values) {
+	if int(key) >= len(s) {
 		return nil, fmt.Errorf("selectorKey not exist %d", key)
 	}
-	return s.Values[key], nil
+	return s[key], nil
 }
 
 func (s SliceSelector) Set(key SelectorKey, _ string, val Value) error {
-	if int(key) >= len(s.Values) {
+	if int(key) >= len(s) {
 		return fmt.Errorf("selectorKey not exist %d", key)
 	}
-	s.Values[key] = val
+	s[key] = val
 	return nil
 }
 
 func (s SliceSelector) Cached(key SelectorKey, _ string) bool {
-	if int(key) >= len(s.Values) {
+	if int(key) >= len(s) {
 		return false
 	}
 	return true
 }
 
-type MapSelector struct {
-	Values map[string]Value
-}
+type MapSelector map[string]Value
 
 func NewMapSelector(vals map[string]interface{}) MapSelector {
-	s := MapSelector{
-		Values: make(map[string]Value),
-	}
+	s := make(map[string]Value, len(vals))
 	for name, val := range vals {
-		s.Values[name] = unifyType(val)
+		s[name] = unifyType(val)
 	}
 	return s
 }
 
 func (s MapSelector) Get(_ SelectorKey, key string) (Value, error) {
-	val, exist := s.Values[key]
+	val, exist := s[key]
 	if !exist {
 		return nil, fmt.Errorf("selectorKey not exist %s", key)
 	}
@@ -177,12 +155,12 @@ func (s MapSelector) Get(_ SelectorKey, key string) (Value, error) {
 }
 
 func (s MapSelector) Set(_ SelectorKey, key string, val Value) error {
-	s.Values[key] = val
+	s[key] = val
 	return nil
 }
 
 func (s MapSelector) Cached(_ SelectorKey, key string) bool {
-	_, exist := s.Values[key]
+	_, exist := s[key]
 	return exist
 }
 

--- a/util.go
+++ b/util.go
@@ -652,25 +652,6 @@ func DumpTable(expr *Expr, skipEventNode bool) string {
 	return sb.String()
 }
 
-type SelectorKeys struct {
-	SelKey SelectorKey
-	StrKey string
-}
-
-func GetSelectorKeys(e *Expr) []SelectorKeys {
-	res := make([]SelectorKeys, len(e.nodes)/2)
-
-	for _, n := range e.nodes {
-		if n.getNodeType() == selector {
-			res = append(res, SelectorKeys{
-				SelKey: n.selKey,
-				StrKey: n.value.(string),
-			})
-		}
-	}
-	return res
-}
-
 func HandleDebugEvent(e *Expr) {
 	go func() {
 		var prev LoopEventData


### PR DESCRIPTION
## Summary
This PR mainly updated `selector.go`, reduced one [dereference operation](https://en.wikipedia.org/wiki/Dereference_operator) in obtaining value from `Selector`, which brought minor performance improvement.

## Test Plan
- [X] Unit test passed
```
❯ go test
ok  	github.com/onheap/eval	4.682s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/onheap/eval_lab/benchmark/branches
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalDev-16      	49385882	        63.28 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16     	54124052	        63.83 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev1-16     	54433180	        62.98 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16    	51758283	        64.01 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev2-16     	55730791	        61.75 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain2-16    	49514638	        66.17 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev3-16     	57099166	        62.37 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain3-16    	54752833	        65.73 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev4-16     	55719435	        61.93 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain4-16    	54172814	        64.46 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev5-16     	56701216	        61.83 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain5-16    	53379057	        64.62 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev6-16     	56875689	        62.17 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain6-16    	54334816	        65.34 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev7-16     	55258840	        62.37 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain7-16    	50714269	        65.64 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev8-16     	55360213	        63.58 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain8-16    	53622234	        64.83 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalDev9-16     	54693601	        61.77 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain9-16    	53364183	        65.31 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/onheap/eval_lab/benchmark/branches	71.013s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     38505|     30000|      6034|        71|    2.103s|
|       2 %|       2 %|     72006|     60000|      9467|       139|    3.513s|
|       3 %|       3 %|     95340|     90000|      2940|         0|    3.755s|
|       4 %|       4 %|    122374|    120000|         0|         0|    3.893s|
|       5 %|       5 %|    152741|    150000|       211|       130|    3.864s|
|       6 %|       6 %|    182631|    180000|       217|        14|    3.918s|
|       7 %|       7 %|    214752|    210000|      2192|       160|    4.034s|
|       8 %|       8 %|    244062|    240000|      1663|         0|    3.917s|
|       9 %|       9 %|    272820|    270000|       262|       159|    3.904s|
|      10 %|      10 %|    302522|    300000|        77|        45|    4.187s|
|      11 %|      11 %|    332413|    330000|         0|        34|    4.486s|
|      12 %|      12 %|    371507|    360000|      8952|       155|    2.942s|
|      13 %|      13 %|    396287|    390000|      3557|       330|    4.495s|
|      14 %|      14 %|    422474|    420000|        73|         1|    4.445s|
|      15 %|      15 %|    452451|    450000|        36|        15|    4.787s|
|      16 %|      16 %|    482655|    480000|        26|       229|     4.75s|
|      17 %|      17 %|    512908|    510000|       102|       406|    4.627s|
|      18 %|      18 %|    543139|    540000|       688|        51|      4.7s|
|      19 %|      19 %|    573404|    570000|       798|       206|    4.712s|
|      20 %|      20 %|    602971|    600000|       561|        10|    4.532s|
|      21 %|      21 %|    632647|    630000|       180|        68|    4.571s|
|      22 %|      22 %|    662535|    660000|         8|       127|    4.352s|
|      23 %|      23 %|    692489|    690000|        17|        72|    4.642s|
|      24 %|      24 %|    729060|    720000|      6624|        36|    4.523s|
|      25 %|      25 %|    752802|    750000|       207|       195|    4.136s|
|      26 %|      26 %|    783456|    780000|       288|       768|    4.328s|
|      27 %|      27 %|    814006|    810000|       947|       659|    4.511s|
|      28 %|      28 %|    842752|    840000|       171|       181|    4.377s|
|      29 %|      29 %|    872632|    870000|       232|         0|    4.454s|
|      30 %|      30 %|    902873|    900000|       266|       207|     4.55s|
|      31 %|      31 %|    932902|    930000|       137|       365|    4.483s|
|      32 %|      32 %|    962581|    960000|       162|        19|    4.511s|
|      33 %|      33 %|    993090|    990000|       674|        16|    4.542s|
|      34 %|      34 %|   1022474|   1020000|        67|         7|    4.462s|
|      35 %|      35 %|   1052726|   1050000|       297|        29|      4.5s|
|      36 %|      36 %|   1082445|   1080000|        32|        13|     4.42s|
|      37 %|      37 %|   1112607|   1110000|       136|        71|    4.455s|
|      38 %|      38 %|   1146004|   1140000|      3574|        30|    4.626s|
|      39 %|      39 %|   1174256|   1170000|      1820|        36|    4.426s|
|      40 %|      40 %|   1203728|   1200000|      1108|       220|    4.526s|
|      41 %|      41 %|   1232752|   1230000|        80|       272|    4.545s|
|      42 %|      42 %|   1264509|   1260000|      2089|        21|    4.572s|
|      43 %|      43 %|   1299234|   1290000|      6830|         4|    5.082s|
|      44 %|      44 %|   1323333|   1320000|       932|         1|    4.494s|
|      45 %|      45 %|   1355434|   1350000|      2199|       835|    5.249s|
|      46 %|      46 %|   1383393|   1380000|       991|         2|    4.908s|
|      47 %|      47 %|   1412501|   1410000|        29|        72|    4.908s|
|      48 %|      48 %|   1443157|   1440000|       671|        86|    4.917s|
|      49 %|      49 %|   1472639|   1470000|       215|        24|     5.26s|
|      50 %|      50 %|   1505184|   1500000|      2676|       108|    5.384s|
|      51 %|      51 %|   1534284|   1530000|      1542|       342|    5.223s|
|      52 %|      52 %|   1567659|   1560000|      5078|       181|    2.727s|
|      53 %|      53 %|   1593018|   1590000|       600|        18|    4.604s|
|      54 %|      54 %|   1623219|   1620000|       498|       321|    5.037s|
|      55 %|      55 %|   1654677|   1650000|      2261|        16|    4.914s|
|      56 %|      56 %|   1682481|   1680000|         0|        87|    4.865s|
|      57 %|      57 %|   1712514|   1710000|       111|         3|    4.718s|
|      58 %|      58 %|   1743235|   1740000|       726|       109|    5.011s|
|      59 %|      59 %|   1772719|   1770000|       198|       121|    4.818s|
|      60 %|      60 %|   1802611|   1800000|       167|        44|    4.811s|
|      61 %|      61 %|   1833988|   1830000|      1559|        30|    4.849s|
|      62 %|      62 %|   1863582|   1860000|      1167|        15|    4.603s|
|      63 %|      63 %|   1892675|   1890000|       225|        50|    4.668s|
|      64 %|      64 %|   1925539|   1920000|      2428|       711|    4.758s|
|      65 %|      65 %|   1953073|   1950000|       526|       147|    4.772s|
|      66 %|      66 %|   1982994|   1980000|       594|         0|    4.641s|
|      67 %|      67 %|   2012531|   2010000|       131|         0|      4.6s|
|      68 %|      68 %|   2042512|   2040000|       110|         2|    4.621s|
|      69 %|      69 %|   2072564|   2070000|         9|       155|    5.054s|
|      70 %|      70 %|   2106248|   2100000|      3537|       311|    4.697s|
|      71 %|      71 %|   2132925|   2130000|       474|        51|    4.538s|
|      72 %|      72 %|   2162996|   2160000|       578|        18|    4.929s|
|      73 %|      73 %|   2192906|   2190000|       485|        21|    4.948s|
|      74 %|      74 %|   2225043|   2220000|      2576|        67|    5.272s|
|      75 %|      75 %|   2252777|   2250000|       246|       131|    4.761s|
|      76 %|      76 %|   2282911|   2280000|       136|       375|    5.353s|
|      77 %|      77 %|   2313587|   2310000|      1052|       135|    5.718s|
|      78 %|      78 %|   2342717|   2340000|       316|         1|    4.839s|
|      79 %|      79 %|   2373429|   2370000|      1028|         1|    4.833s|
|      80 %|      80 %|   2405033|   2400000|      2573|        60|    5.048s|
|      81 %|      81 %|   2432858|   2430000|       280|       178|    4.645s|
|      82 %|      82 %|   2463579|   2460000|      1163|        16|     5.03s|
|      83 %|      83 %|   2492421|   2490000|         0|        25|    5.252s|
|      84 %|      84 %|   2522687|   2520000|       158|       129|    4.798s|
|      85 %|      85 %|   2552476|   2550000|         0|        82|    4.985s|
|      86 %|      86 %|   2584201|   2580000|      1794|         7|    5.044s|
|      87 %|      87 %|   2612380|   2610000|         0|         0|    5.189s|
|      88 %|      88 %|   2643083|   2640000|       679|         4|    5.187s|
|      89 %|      89 %|   2672921|   2670000|       346|       175|    5.053s|
|      90 %|      90 %|   2705684|   2700000|      3134|       150|     5.13s|
|      91 %|      91 %|   2732651|   2730000|       247|         5|    4.862s|
|      92 %|      92 %|   2762679|   2760000|       272|         7|    4.613s|
|      93 %|      93 %|   2793505|   2790000|      1006|        99|    4.898s|
|      94 %|      94 %|   2823197|   2820000|       700|        97|    4.735s|
|      95 %|      95 %|   2852649|   2850000|       246|         3|    4.619s|
|      96 %|      96 %|   2882447|   2880000|         6|        41|    4.828s|
|      97 %|      97 %|   2912704|   2910000|       199|       105|    5.015s|
|      98 %|      98 %|   2942730|   2940000|       294|        36|    5.175s|
|      99 %|      99 %|   2973064|   2970000|       332|       332|    5.329s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    4.884s|
PASS
ok  	github.com/onheap/eval	470.507s
```

## Reviewers
@onheap